### PR TITLE
pentaho-carte - Möglichkeit für initContainer und extraEnvVars geschaffen

### DIFF
--- a/charts/pentaho-carte/Chart.yaml
+++ b/charts/pentaho-carte/Chart.yaml
@@ -3,7 +3,7 @@ name: pentaho-carte
 description: Pentaho Data Integration installation and starts the Pentaho Carte Server
 type: application
 # Chart version.
-version: 0.1.0
+version: 0.1.1
 # Pentaho Dataintegration version
 appVersion: "0.0.2"
 maintainers:

--- a/charts/pentaho-carte/README.md
+++ b/charts/pentaho-carte/README.md
@@ -17,7 +17,7 @@ The command deploys pentaho-carte on the Kubernetes cluster with some default co
 ## Configuration
 
 | Key                                        | Type   | Default                 | Description                             |
-|--------------------------------------------|--------|-------------------------|-----------------------------------------|
+| ------------------------------------------ | ------ | ----------------------- | --------------------------------------- |
 | replicaCount                               | int    | `1`                     | Number of replicas                      |
 | image.repository                           | string | `"itatm/pentaho-carte"` | Image to use for deploying              |
 | image.pullPolicy                           | string | `"IfNotPresent"`        | Image pull policy                       |
@@ -66,3 +66,5 @@ The command deploys pentaho-carte on the Kubernetes cluster with some default co
 | nodeSelector                               | object | `{}`                    | Kubernetes node selector                |
 | tolerations                                | list   | `[]`                    | Kubernetes tolerations                  |
 | affinity                                   | object | `{}`                    | Kubernetes node affinity                |
+| initContainers                             | list   | `[]`                    | Extra initContainers for the pods       |
+| extraEnvVars                               | list   | `[]`                    | Extra environment variables             |

--- a/charts/pentaho-carte/templates/deployment.yaml
+++ b/charts/pentaho-carte/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
       serviceAccountName: {{ include "pentaho-carte.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8}}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -40,6 +44,10 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          env:
+          {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+          {{- end}}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/charts/pentaho-carte/values.yaml
+++ b/charts/pentaho-carte/values.yaml
@@ -28,10 +28,12 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -47,14 +49,15 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts: []
-#    - host: chart-example.local
-#      paths:
-#        - path: /
-#          pathType: ImplementationSpecific
+  #    - host: chart-example.local
+  #      paths:
+  #        - path: /
+  #          pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
@@ -108,6 +111,10 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+extraEnvVars: []
+#  - name: "TZ"
+#    value: "Europe/Berlin"
+
 # Additional volumes on the output Deployment definition.
 volumes: []
 # - name: foo
@@ -126,3 +133,15 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# can be used to add init containers
+initContainers:
+  []
+  # - name: my-init-container-name
+  #   image: some-image:latest
+  #   env:
+  #     - name: AWS_DEFAULT_REGION
+  #       value: "eu-central-1"
+  #   volumeMounts:
+  #     - name: help-zammad
+  #       mountPath: /opt/zammad


### PR DESCRIPTION
**Description**

Wir benötigen im Helm-Chart die Möglichkeit initContainer anzulegen um darin zusätzliche Treiberkomponenten im Server bereitzustellen.
Wir benötigen auch die Möglichkeit zusätzliche/eigenen Environmentvariablen anzulegen um damit die Jobausführung individuell steuern zu können. 

**Reference**

Issues #XXX
