### PR TITLE
Zammad ldap syc/make tags configurable

### DIFF
--- a/charts/zammad-ldap-sync/Chart.yaml
+++ b/charts/zammad-ldap-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad-ldap-sync
-version: 0.3.0
+version: 0.4.0
 maintainers:
   - name: klml
     email: klml@muenchen.de

--- a/charts/zammad-ldap-sync/templates/cronjob.yaml
+++ b/charts/zammad-ldap-sync/templates/cronjob.yaml
@@ -10,8 +10,8 @@ spec:
         spec:
           containers:
           - name: zammad-ldap-sync
-            image: ghcr.io/it-at-m/zammad-ldap-sync:dev
-            imagePullPolicy: Always
+            image: "{{ .Values.ldapSync.image.registry }}/{{ .Values.ldapSync.image.repository }}:{{ .Values.ldapSync.image.tag | default 'dev' }}"
+            imagePullPolicy: {{ .Values.ldapSync.image.pullPolicy }}
             envFrom:
             - secretRef:
                 name: {{ .Values.ldapSync.cronjob.secret }}

--- a/charts/zammad-ldap-sync/templates/cronjob.yaml
+++ b/charts/zammad-ldap-sync/templates/cronjob.yaml
@@ -10,7 +10,7 @@ spec:
         spec:
           containers:
           - name: zammad-ldap-sync
-            image: "{{ .Values.ldapSync.image.registry }}/{{ .Values.ldapSync.image.repository }}:{{ .Values.ldapSync.image.tag | default 'dev' }}"
+            image: "{{ .Values.ldapSync.image.registry }}/{{ .Values.ldapSync.image.repository }}:{{ .Values.ldapSync.image.tag }}"
             imagePullPolicy: {{ .Values.ldapSync.image.pullPolicy }}
             envFrom:
             - secretRef:

--- a/charts/zammad-ldap-sync/values.yaml
+++ b/charts/zammad-ldap-sync/values.yaml
@@ -1,4 +1,11 @@
+
+
 ldapSync:
+  image:
+    registry: ghcr.io
+    repository: it-at-m/zammad-ldap-sync
+    pullPolicy: Always
+    #tag: '' # default is 'dev'
   cronjob:
     schedule: "0 2 * * *"
   # Must be present.

--- a/charts/zammad-ldap-sync/values.yaml
+++ b/charts/zammad-ldap-sync/values.yaml
@@ -1,5 +1,3 @@
-
-
 ldapSync:
   image:
     registry: ghcr.io

--- a/charts/zammad-ldap-sync/values.yaml
+++ b/charts/zammad-ldap-sync/values.yaml
@@ -3,7 +3,8 @@ ldapSync:
     registry: ghcr.io
     repository: it-at-m/zammad-ldap-sync
     pullPolicy: Always
-    tag: dev # default is 'dev'
+    # default tag is 'dev'
+    tag: dev
   cronjob:
     schedule: "0 2 * * *"
   # Must be present.

--- a/charts/zammad-ldap-sync/values.yaml
+++ b/charts/zammad-ldap-sync/values.yaml
@@ -3,7 +3,7 @@ ldapSync:
     registry: ghcr.io
     repository: it-at-m/zammad-ldap-sync
     pullPolicy: Always
-    #tag: '' # default is 'dev'
+    tag: dev # default is 'dev'
   cronjob:
     schedule: "0 2 * * *"
   # Must be present.


### PR DESCRIPTION
**Description**

Tags should be variable since you usually want to deploy different image versions to different environments.

**Reference**

Issues MPDZ2-756
