### PR TITLE
Penthao-carte: Fix liveness und readinessProbe

### DIFF
--- a/charts/pentaho-carte/Chart.yaml
+++ b/charts/pentaho-carte/Chart.yaml
@@ -3,7 +3,7 @@ name: pentaho-carte
 description: Pentaho Data Integration installation and starts the Pentaho Carte Server
 type: application
 # Chart version.
-version: 0.1.1
+version: 0.1.2
 # Pentaho Dataintegration version
 appVersion: "0.0.2"
 maintainers:

--- a/charts/pentaho-carte/README.md
+++ b/charts/pentaho-carte/README.md
@@ -53,10 +53,12 @@ The command deploys pentaho-carte on the Kubernetes cluster with some default co
 | route.tls.caCertificate                    | string | `""`                    | Route tls ca certificate                |
 | route.tls.destinationCACertificate         | string | `""`                    | Route tls destination ca certificate    |
 | resources                                  | object | `{}`                    | Pod resources                           |
-| livenessProbe.httpGet.path                 | string | `/`                     | Path to use for liveness probe          |
-| livenessProbe.httpGet.port                 | string | `http`                  | Port to use for liveness probe          |
-| readinessProbe.httpGet.path                | string | `/`                     | Path to use for readiness probe         |
-| readinessProbe.httpGet.port                | string | `http`                  | Path to use for readiness probe         |
+| livenessProbe.tcpSocket.port               | int    | `8080`                  | Path to use for liveness probe          |
+| livenessProbe.initialDelaySeconds          | int    | `60`                    | Initial delay before probe starts       |
+| livenessProbe.periodSeconds                | int    | `10`                    | The delay between performing probes     |
+| readinessProbe.tcpSocket.port              | int    | `8080`                  | Path to use for liveness probe          |
+| readinessProbe.initialDelaySeconds         | int    | `60`                    | Initial delay before probe starts       |
+| readinessProbe.periodSeconds               | int    | `10`                    | The delay between performing probes     |
 | autoscaling.enabled                        | bool   | `false`                 | Enable autoscaling                      |
 | autoscaling.minReplicas                    | int    | `1`                     | Minimal replicas                        |
 | autoscaling.maxReplicas                    | int    | `100`                   | Maximal replicas                        |

--- a/charts/pentaho-carte/values.yaml
+++ b/charts/pentaho-carte/values.yaml
@@ -89,20 +89,16 @@ resources:
     cpu: 100m
     memory: 1024Mi
 
-  livenessProbe:
-    httpGet:
-      path: /
-      port: http
-      httpHeaders:
-        - name: Authorization
-          value: Basic Y2x1c3RlcjpjbHVzdGVy
-  readinessProbe:
-    httpGet:
-      path: /
-      port: http
-      httpHeaders:
-        - name: Authorization
-          value: Basic Y2x1c3RlcjpjbHVzdGVy
+readinessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 10
+livenessProbe:
+  tcpSocket:
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 10
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
**Description**

Die Einrückung der `livenessProbe` und `readynessProbe` ist aktuell noch fehlerhaft.
Die Werte werden in den defaultwerten dem `resources:` Block zugeschrieben und damit nie geladen.
Ein lokales setzen der richtigen Einrückung führt dazu, dass die falsch eingerückten Werte trotzdem noch aus der default values.yaml gezogen werden. Das führt zu WARNINGS im Deployment:

![grafik](https://github.com/user-attachments/assets/0cac23af-9773-46ef-8775-ef3c28e78605)

Ich habe die Einrückung gefixt.

Zusätzlich habe ich die Art der Default-Probe von `HTTP Get` auf `TCP socket` geändert:

Die Endpunkte des Carte sind mittels BasicAuth abgesichert. Für eine `HTTP Get`-Probe muss daher immer ein BasicAuth-Header mitgeschickt werden. Das führt dazu, dass wir in unseren values.yaml credentials stehen haben.

Wir müssten den Zugriff auf unsere produktiven values.yaml daher eigentlich immer einschränken und wie ein Secret behandeln und würden credentials in unseren Repos führen sobald wir "Infrastructure as Code" machen.

Eigentlich reicht uns hier zu testen, ob der Pod schon auf den Port 8080 lauscht. (Das ist der letzte Schritt den der Carte macht wenn er startet). Dazu benötigen wir keine Credentials.
Mit der `TCP socket` Probe können wir also auch testen, ob der Pod verfügbar ist und spaaren uns die Credentials in den yamls.

So verleiten wir die nutzer nicht dazu, ihre Credentials in der yaml offen zu legen und haben trotzdem eine funktionierende Probe.

(So macht es auch Hitatchi in den Beispielen zu ihren anderen Containern: https://github.com/hv-support/pentaho-containers/blob/f8e8238699aca3b2ea6b35f8cdf1e8a654cd7db2/kubernetes/manifests/tray-gke.yaml#L46)

**Reference**

Issues #XXX
