### PR TITLE
Hotfix invalid name dn-identifier-1

### DIFF
--- a/charts/zammad-ldap-sync/Chart.yaml
+++ b/charts/zammad-ldap-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad-ldap-sync
-version: 0.4.0
+version: 0.4.1
 maintainers:
   - name: klml
     email: klml@muenchen.de

--- a/charts/zammad-ldap-sync/values.yaml
+++ b/charts/zammad-ldap-sync/values.yaml
@@ -32,12 +32,12 @@ ldapSync:
         organizational-units:
           identifier-1:
             distinguished-names:
-              - dn-identifier-1
+#              - dn-identifier-1
             user-search-base: user-dn-search-base-dent-1
             ou-search-base: ou-dn-search-base-dent-1
           identifier-2:
             distinguished-names:
-              - dn-identifier-2
+#              - dn-identifier-2
             user-search-base: user-dn-search-base-dent-2
             ou-search-base: ou-dn-search-base-dent-2
         message:


### PR DESCRIPTION
**Description**
Don't merge helm-charts organizational-units

- identifier-1
- identifier-2 

into zammad-ldap-sync cron-job organizational-units list. Incomplete configurations are not taken into account by spring-boot initialization.

Short description or comments

**Reference**

Issues #XXX
