### PR TITLE
[refarch-gateway] Bug/fix hazelcast role permissions

### DIFF
--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.3.1
+version: 1.3.2-1
 appVersion: 1.3.1
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://opensource.muenchen.de/assets/itm-logo-256.png

--- a/charts/refarch-gateway/templates/hazelcast-role-binding.yaml
+++ b/charts/refarch-gateway/templates/hazelcast-role-binding.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hazelcast.enabled .Values.serviceAccount.create }}
+{{- if and .Values.hazelcast.assignRoleToServiceAccount .Values.serviceAccount.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/refarch-gateway/templates/hazelcast-role.yaml
+++ b/charts/refarch-gateway/templates/hazelcast-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.hazelcast.enabled }}
+{{- if and .Values.hazelcast.assignRoleToServiceAccount .Values.serviceAccount.create }}
 # based on https://github.com/hazelcast/hazelcast/blob/master/kubernetes-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -124,3 +124,4 @@ applicationYML:
 
 hazelcast:
   enabled: true
+  assignRoleToServiceAccount: true


### PR DESCRIPTION
**Description**

Fix rbac resources can't be created by internal ci user.
- Add value to enable hazelcast role and rolebinding to service account
- Create hazelcast role only if service account enabled
