### PR TITLE
[refarch-gateway] bump app version to 1.4.1

### DIFF
--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.3.2
-appVersion: 1.3.1
+version: 1.4.1
+appVersion: 1.4.1
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://opensource.muenchen.de/assets/itm-logo-256.png
 sources:


### PR DESCRIPTION
**Description**

Bump refarch-gateway version to 1.4.1
See release notes:
- https://github.com/it-at-m/refarch/releases/tag/refarch-gateway_1.4.1
- https://github.com/it-at-m/refarch/releases/tag/refarch-gateway_1.4.0
