### PR TITLE
Zammad ldap sync create secret mpdz2 564 pipeline secret

### DIFF
--- a/charts/zammad-ldap-sync/Chart.yaml
+++ b/charts/zammad-ldap-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad-ldap-sync
-version: 0.6.1
+version: 0.6.2
 maintainers:
   - name: klml
     email: klml@muenchen.de

--- a/charts/zammad-ldap-sync/templates/secret.yaml
+++ b/charts/zammad-ldap-sync/templates/secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: zammad-ldap-sync
 type: Opaque
 data:
-  spring.mail.password: {{ .Values.ldapSync.pipeline.mailPassword | b64enc }}
-  zammad.token: {{ .Values.ldapSync.pipeline.zammadToken | b64enc}}
+  spring.mail.password: {{.Values.ldapSync.pipeline.mailPassword | b64enc}}
+  zammad.token: {{.Values.ldapSync.pipeline.zammadToken | b64enc}}

--- a/charts/zammad-ldap-sync/templates/secret.yaml
+++ b/charts/zammad-ldap-sync/templates/secret.yaml
@@ -5,5 +5,4 @@ metadata:
 type: Opaque
 data:
   spring.mail.password: {{ .Values.ldapSync.pipeline.mailPassword | b64enc }}
-  spring.mail.username: {{ .Values.ldapSync.applicationYML.spring.mail.username | b64enc}}
   zammad.token: {{ .Values.ldapSync.pipeline.zammadToken | b64enc}}

--- a/charts/zammad-ldap-sync/templates/secret.yaml
+++ b/charts/zammad-ldap-sync/templates/secret.yaml
@@ -4,6 +4,6 @@ metadata:
   name: zammad-ldap-sync
 type: Opaque
 data:
-  spring.mail.password: {{ .Values.ldapSync.applicationYML.spring.mail.password | b64enc }}
+  spring.mail.password: {{ .Values.ldapSync.pipeline.mailPassword | b64enc }}
   spring.mail.username: {{ .Values.ldapSync.applicationYML.spring.mail.username | b64enc}}
-  zammad.token: {{ .Values.ldapSync.zammadToken | b64enc}}
+  zammad.token: {{ .Values.ldapSync.pipeline.zammadToken | b64enc}}

--- a/charts/zammad-ldap-sync/values.yaml
+++ b/charts/zammad-ldap-sync/values.yaml
@@ -1,5 +1,7 @@
 ldapSync:
-  zammadToken: ReplaceWithZammadAccessToken
+  pipeline:
+    mailPassword: ReplaceWithMailAccountPassword
+    zammadToken: ReplaceWithZammadAccessToken
   image:
     registry: ghcr.io
     repository: it-at-m/zammad-ldap-sync
@@ -21,7 +23,6 @@ ldapSync:
         host: mail.example.com
         port: 1
         username: ReplaceWithMailAccountUsername
-        password: ReplaceWithMailAccountPassword
     ldap:
       url: ldaps://...
     sync:


### PR DESCRIPTION
**Description**

Short description or comments

**Reference**

Issues #XXX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Revised the configuration for integration credentials. The email password and integration token are now sourced from a dedicated pipeline section for improved organization and security.
	- Removed an unused email username field to streamline the settings.
	- Updated the version of the `zammad-ldap-sync` chart from `0.6.1` to `0.6.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->