### PR TITLE
add dave external charts condition

### DIFF
--- a/charts/dave/Chart.lock
+++ b/charts/dave/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: eai
   repository: ""
   version: '*'
-digest: sha256:c50f02bd28aecfae0cd393e22e6f2e3d375769160c5cf1a6f1331fb22b97c26c
-generated: "2024-05-24T15:08:36.553513836Z"
+digest: sha256:5209fef7581d40af348f283859c60aac82c45118869ab475e29c7681c0155e80
+generated: "2025-03-12T17:04:15.0370364+01:00"

--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "v1.0.0"
 maintainers:
   - name: gislab-augsburg

--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -17,9 +17,11 @@ dependencies:
   - name: elasticsearch
     repository: https://charts.bitnami.com/bitnami
     version: 19.17.0
+    condition: externalCharts.elasticsearch.enabled
   - name: postgresql
     repository: https://charts.bitnami.com/bitnami
     version: 14.3.3
+    condition: externalCharts.postgresql.enabled
   - name: backend
     version: "*"
   - name: frontend

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -18,6 +18,14 @@ global:
     - name: "SPRING_SESSION_TIMEOUT"
       value: "3600"
 
+externalCharts:
+  elasticsearch:
+    # enable/disable elasticsearch chart dependency
+    enabled: true
+  postgresql:
+    # enable/disable postgresql chart dependency
+    enabled: true
+
 # Dave Backend
 backend:
   replicaCount: 1


### PR DESCRIPTION
**Description**

in the helm charts from dave, [elasticsearch and postgresql are currently installed](https://github.com/it-at-m/helm-charts/blob/main/charts/dave/Chart.yaml). However, we cannot use these internally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated version to 0.0.7 for improved functionality.
  - Added configuration toggles allowing you to selectively enable external services such as Elasticsearch and PostgreSQL.
  - Introduced a new section for external chart dependencies, enhancing deployment customization options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->