### PR TITLE
[dave] testing profile no-security

### DIFF
--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "v1.0.0"
 maintainers:
   - name: gislab-augsburg

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -19,7 +19,7 @@ backend:
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
         --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
       KEYCLOAK_AUTH-SERVER-URL: https://sso.example.com/auth
-      SPRING_PROFILES_ACTIVE: no-security
+      SPRING_PROFILES_ACTIVE: dev,no-security
     # Dave Email Settings
     email:
       DAVE_EMAIL_RECEIVER_HOSTNAME: imap.example.com
@@ -50,6 +50,7 @@ admin-portal:
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
     SPRING_CLOUD_GATEWAY_ROUTES_0_URI: https://sso.example.com/
     SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: https://sso.example.com/auth/realms/${spring.realm}
+    SPRING_PROFILES_ACTIVE: dev,no-security
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -97,6 +98,7 @@ frontend:
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
     SPRING_CLOUD_GATEWAY_ROUTES_0_URI: https://sso.example.com/
     SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: https://sso.example.com/auth/realms/${spring.realm}
+    SPRING_PROFILES_ACTIVE: dev,no-security
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -128,6 +130,7 @@ selfservice-portal:
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
     SPRING_CLOUD_GATEWAY_ROUTES_0_URI: https://sso.example.com/
     SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: https://sso.example.com/auth/realms/${spring.realm}
+    SPRING_PROFILES_ACTIVE: dev,no-security
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts


### PR DESCRIPTION
**Description**

During CI, the check "Run chart-testing (install)" fails to connect to the KeyCloak instance https://sso.example.com/ because it doesn't exist. To avoid this, the Spring profile "no-security" is used (see https://github.com/it-at-m/helm-charts/blob/main/charts/refarch-gateway/ci/test-values.yaml).

**Reference**

Same attempt #86 but step by step


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version to 0.0.8.
  - Revised configuration settings to include an additional development profile for enhanced environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->