### PR TITLE
[dave] Add keycloak subchart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,4 @@ jobs:
         uses: helm/kind-action@v1
       - name: Run chart-testing (install)
         if: "steps.list-changed.outputs.changed == 'true' && ! contains(env.commitmsg, '[skip install]')"
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --debug --target-branch ${{ github.event.repository.default_branch }}

--- a/charts/dave/Chart.lock
+++ b/charts/dave/Chart.lock
@@ -5,6 +5,9 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 14.3.3
+- name: keycloak
+  repository: https://charts.bitnami.com/bitnami
+  version: 24.4.13
 - name: backend
   repository: ""
   version: '*'
@@ -20,5 +23,5 @@ dependencies:
 - name: eai
   repository: ""
   version: '*'
-digest: sha256:5209fef7581d40af348f283859c60aac82c45118869ab475e29c7681c0155e80
-generated: "2025-03-12T17:04:15.0370364+01:00"
+digest: sha256:04fa1828de8ba6c5e62a70c1fe9306eb4d651a8fd79beddc49c415b06cd1857e
+generated: "2025-03-20T10:49:05.232444674+01:00"

--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "v1.0.0"
 maintainers:
   - name: gislab-augsburg

--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -22,6 +22,10 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 14.3.3
     condition: externalCharts.postgresql.enabled
+  - name: keycloak
+    repository: https://charts.bitnami.com/bitnami
+    version: 24.4.13
+    condition: externalCharts.keycloak.enabled
   - name: backend
     version: "*"
   - name: frontend

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -18,7 +18,7 @@ backend:
         --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
         --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
-      KEYCLOAK_AUTH-SERVER-URL: http://keycloak.local/auth
+      KEYCLOAK_AUTH-SERVER-URL: http://dave-keycloak/auth
       SPRING_PROFILES_ACTIVE: no-security
     # Dave Email Settings
     email:
@@ -49,8 +49,8 @@ admin-portal:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://keycloak.local/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://keycloak.local/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -96,8 +96,8 @@ frontend:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://keycloak.local/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://keycloak.local/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -127,8 +127,8 @@ selfservice-portal:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://keycloak.local/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://keycloak.local/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -149,5 +149,4 @@ selfservice-portal:
             pathType: ImplementationSpecific
 
 keycloak:
-  ingress:
-    enabled: true
+  fullnameOverride: "dave-keycloak"

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -50,7 +50,7 @@ admin-portal:
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
     SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -97,7 +97,7 @@ frontend:
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
     SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -128,7 +128,7 @@ selfservice-portal:
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
     SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -18,7 +18,7 @@ backend:
         --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
         --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
-      KEYCLOAK_AUTH-SERVER-URL: http://dave-keycloak/auth
+      KEYCLOAK_AUTH-SERVER-URL: http://keycloak.local/auth
       SPRING_PROFILES_ACTIVE: no-security
     # Dave Email Settings
     email:
@@ -49,8 +49,8 @@ admin-portal:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://keycloak.local/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://keycloak.local/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -96,8 +96,8 @@ frontend:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://keycloak.local/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://keycloak.local/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -127,8 +127,8 @@ selfservice-portal:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://keycloak.local/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://keycloak.local/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -149,4 +149,5 @@ selfservice-portal:
             pathType: ImplementationSpecific
 
 keycloak:
-  fullnameOverride: "dave-keycloak"
+  ingress:
+    enabled: true

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -18,8 +18,7 @@ backend:
         --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
         --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
-      KEYCLOAK_AUTH-SERVER-URL: http://dave-keycloak/auth
-      SPRING_PROFILES_ACTIVE: no-security
+      KEYCLOAK_AUTH-SERVER-URL: http://dave-keycloak
     # Dave Email Settings
     email:
       DAVE_EMAIL_RECEIVER_HOSTNAME: imap.example.com
@@ -150,3 +149,6 @@ selfservice-portal:
 
 keycloak:
   fullnameOverride: "dave-keycloak"
+  keycloakConfigCli:
+    annotations:
+      helm.sh/hook: null # to trigger immediate execution of keycloak-config-ci

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -151,4 +151,5 @@ keycloak:
   fullnameOverride: "dave-keycloak"
   keycloakConfigCli:
     annotations:
-      helm.sh/hook: null # to trigger immediate execution of keycloak-config-ci
+      # to trigger immediate execution of keycloak-config-ci
+      helm.sh/hook: null

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -2,7 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-
 # Global values
 global:
   credentials:
@@ -13,7 +12,8 @@ backend:
   # Environment Variables
   extraEnvVars:
     env:
-      JAVA_OPTIONS: -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit
+      JAVA_OPTIONS:
+        -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit
         -Xmx1g --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
         --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
@@ -43,7 +43,8 @@ backend:
 admin-portal:
   # Environment variables
   extraEnvVars:
-    JAVA_OPTIONS: -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit
+    JAVA_OPTIONS:
+      -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit
       --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
@@ -85,12 +86,12 @@ eai:
   #       secretName: cacerts
   #       defaultMode: 420
 
-
 # Dave Frontend
 frontend:
   # Environment variables
   extraEnvVars:
-    JAVA_OPTIONS: -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit
+    JAVA_OPTIONS:
+      -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit
       --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
@@ -116,12 +117,12 @@ frontend:
           - path: /
             pathType: ImplementationSpecific
 
-
 # Dave Selfservice-Portal
 selfservice-portal:
   # Environment variables
   extraEnvVars:
-    JAVA_OPTIONS: -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit
+    JAVA_OPTIONS:
+      -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit
       --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
@@ -146,3 +147,6 @@ selfservice-portal:
         paths:
           - path: /
             pathType: ImplementationSpecific
+
+keycloak:
+  fullnameOverride: "dave-keycloak"

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -18,7 +18,7 @@ backend:
         --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
         --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
-      KEYCLOAK_AUTH-SERVER-URL: https://sso.example.com/auth
+      KEYCLOAK_AUTH-SERVER-URL: http://dave-keycloak/auth
       SPRING_PROFILES_ACTIVE: no-security
     # Dave Email Settings
     email:
@@ -48,8 +48,8 @@ admin-portal:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: https://sso.example.com/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: https://sso.example.com/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -95,8 +95,8 @@ frontend:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: https://sso.example.com/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: https://sso.example.com/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -126,8 +126,8 @@ selfservice-portal:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: https://sso.example.com/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: https://sso.example.com/auth/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
+    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/auth/realms/${spring.realm}
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -25,6 +25,9 @@ externalCharts:
   postgresql:
     # enable/disable postgresql chart dependency
     enabled: true
+  keycloak:
+    # enable/disable keycloak chart dependency
+    enabled: true
 
 # Dave Backend
 backend:
@@ -314,3 +317,32 @@ postgresql:
       enabled: false
     podSecurityContext:
       enabled: false
+
+# Keycloak
+# https://github.com/bitnami/charts/tree/bitnami/keycloak
+keycloak:
+  keycloakConfigCli:
+    enabled: true
+    initContainers: |
+      - name: fetch-config
+        image: {{ include "common.images.image" (dict "imageRoot" (dict "repository" "bitnami/os-shell" "tag" "latest") "global" .Values.global) }}
+        command:
+          - /bin/sh
+          - -c
+          - |
+            curl -L https://github.com/it-at-m/dave-backend/raw/refs/heads/sprint/sso-config/sso-client.json |
+              jq '{"clients": [.], "enabled": true, "realm": "Dave", "displayName": "DAVe"}' > /config/sso.json
+        volumeMounts:
+          - name: config-volume
+            mountPath: /config
+        securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.keycloakConfigCli.containerSecurityContext "context" $) | nindent 4 }}
+    extraVolumes:
+      - name: config-volume
+        emptyDir:
+          sizeLimit: 10Mi
+    extraVolumeMounts:
+      - name: config-volume
+        mountPath: /config
+    extraEnvVars:
+      - name: IMPORT_FILES_LOCATIONS
+        value: /config/*

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -321,6 +321,9 @@ postgresql:
 # Keycloak
 # https://github.com/bitnami/charts/tree/bitnami/keycloak
 keycloak:
+  postgresql:
+    nameOverride: keycloak-postgresql
+
   keycloakConfigCli:
     enabled: true
     initContainers: |

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -94,7 +94,7 @@ backend:
       DAVE_EMAIL_RECEIVER_UPDATE-INTERVAL: "5000"
       DAVE_EMAIL_RECEIVER_HOSTNAME: <Hostname>
       DAVE_EMAIL_ADDRESS: <Email-Adress>
-      DAVE_EMAIL_RECEIVER_CUT_EMAIL_BODY_LINE_BEGINS_WITH_STRINGS: 'Von:;Gesendet:'
+      DAVE_EMAIL_RECEIVER_CUT_EMAIL_BODY_LINE_BEGINS_WITH_STRINGS: "Von:;Gesendet:"
       DAVE_EMAIL_RECEIVER_CUT_EMAIL_BODY_LINE_CONTAINS_STRINGS: <Email Body Strings>
       DAVE_EMAIL_RECEIVER_UPDATE_INTERVAL: "30000"
   # Credentials
@@ -106,7 +106,6 @@ backend:
   # Volume for CA-Certfificates
   extraVolumeMounts: []
   extraVolumes: []
-
 
 # Dave Admin-Portal
 admin-portal:
@@ -156,7 +155,6 @@ admin-portal:
   service:
     port: 8080
 
-
 # Dave EAI
 eai:
   replicaCount: 1
@@ -174,7 +172,6 @@ eai:
   # Volume for CA-Certfificates
   extraVolumeMounts: []
   extraVolumes: []
-
 
 # Dave Frontend
 frontend:


### PR DESCRIPTION
**Description**

Adds the Bitnami Keycloak chart as a subchart and configures it using the sso-client.json from the dave-backend repo.

What's missing is the client roles (it-at-m/dave-backend#265).

What's also missing is the client secret, which currently has to be extracted from the installed Keycloak and put into `.Values.global.credentials.SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT-SECRET`. My proposal would be to let Helm generate it in a Secret and reference it from there in the frontends as well as in the keycloak-config-cli job, which will import it into Keycloak.

**Reference**

Fixes #101 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enabled integration with Keycloak for enhanced authentication management.
  - Introduced a new dependency for Keycloak in the Helm chart.
  - Added a new configuration section for Keycloak, allowing for detailed management and customization.
  - Improved readability of environment variable configurations across multiple components.
  - Added a new section for Keycloak in the test values configuration.

- **Bug Fixes**
  - Corrected URLs for Keycloak authentication server and Spring Cloud Gateway routes.

- **Updates**
  - Updated Helm chart version from 0.0.7 to 0.0.8.
  - Enabled debug output in the CI workflow for better troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->