### PR TITLE
[dave] Allow to include backend env vars from external secrets

### DIFF
--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.0.10
+version: 0.0.9
 appVersion: "v1.0.0"
 maintainers:
   - name: gislab-augsburg

--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.0.8
+version: 0.0.10
 appVersion: "v1.0.0"
 maintainers:
   - name: gislab-augsburg

--- a/charts/dave/charts/backend/templates/deployment.yaml
+++ b/charts/dave/charts/backend/templates/deployment.yaml
@@ -60,6 +60,9 @@ spec:
           {{- with .Values.global.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
           {{- end}}
+          {{- with .Values.extraEnvVarsSources }}
+            {{- toYaml . | nindent 12 }}
+          {{- end}}
           envFrom:
             - configMapRef:
                 name: {{ include "daveBackend.fullname" . }}

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -100,6 +100,8 @@ backend:
     DAVE_EMAIL_PASSWORD: <Email-Password>
     ELASTICSEARCH_HOST: dave-elasticsearch
     ELASTICSEARCH_PASSWORD: ""
+  # Environment variables from other secrets/config maps
+  extraEnvVarsSources: []
   # Volume for CA-Certfificates
   extraVolumeMounts: []
   extraVolumes: []


### PR DESCRIPTION
**Description**

It would be useful to reference single keys from other secrets. For example, the Bitnami charts (in this case Elasticsearch and PostgreSQL) all support generating random passwords. With this change, one could simply reference them:
```yaml
backend:
  extraEnvVarsSources:
    - name: ELASTICSEARCH_PASSWORD      
      valueFrom:                        
        secretKeyRef:                   
          name: dave-elasticsearch      
          key: elasticsearch-password   
    - name: SPRING_DATASOURCE_PASSWORD  
      valueFrom:                        
        secretKeyRef:                   
          name: dave-postgresql         
          key: password                 
```

This would be more secure than specifying them manually in the Helm chart (`dave_pwd`) and makes rotating them easier.

Note that this is usually accomplished with the `extraEnvVars` value, but you already used that to generate ConfigMaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the backend deployment configuration to support additional environment variable sources.
  - Introduced a new configuration option to allow specifying supplementary environment variable sources alongside existing settings for increased deployment flexibility.
- **Version Update**
  - Updated application version from 0.0.8 to 0.0.9.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->