### PR TITLE
:sparkles: introduced envFrom to deployment.yaml and in values.yaml f…

### DIFF
--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.4.4
+version: 1.4.5
 appVersion: 1.4.3
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://assets.muenchen.de/logos/itm/itm-logo-256.png

--- a/charts/refarch-gateway/templates/deployment.yaml
+++ b/charts/refarch-gateway/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
             - name: REFARCH_HAZELCAST_SERVICENAME
               value: {{ include "refarch-gateway.fullname" . }}
             {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{- toYaml .Values.envFrom | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /deployments/config

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -114,6 +114,8 @@ env:
 # Additional env on the output Deployment definition.
 envAppend: []
 
+envFrom: []
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -114,6 +114,7 @@ env:
 # Additional env on the output Deployment definition.
 envAppend: []
 
+# List of ConfigMapRef or SecretRef to inject environment variables
 envFrom: []
 
 nodeSelector: {}


### PR DESCRIPTION
**Description**

- added envFrom to deployment template
- added envFrom to values for auto-completion

**Reference**

Issues #120 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying external environment variable sources (such as ConfigMaps or Secrets) in the deployment configuration via a new `envFrom` field.
  - Introduced a new `envFrom` configuration option in the values file to allow users to define environment variable sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->