### PR TITLE
feat(refarch-gateway): properties path and args configurable and bump to 1.5.0

### DIFF
--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.4.5
-appVersion: 1.4.3
+version: 1.5.0
+appVersion: 1.5.0
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://assets.muenchen.de/logos/itm/itm-logo-256.png
 sources:

--- a/charts/refarch-gateway/templates/deployment.yaml
+++ b/charts/refarch-gateway/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: config
-              mountPath: /deployments/config
+              mountPath: {{ .Values.applicationYmlMountPath }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/refarch-gateway/templates/deployment.yaml
+++ b/charts/refarch-gateway/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
           {{- end }}
           volumeMounts:
             - name: config
-              mountPath: {{ .Values.applicationYmlMountPath }}
+              mountPath: {{ .Values.applicationYMLMountPath }}
           {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/refarch-gateway/templates/deployment.yaml
+++ b/charts/refarch-gateway/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.args }}
+          args:
+            {{- toYaml .Values.args | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -123,6 +123,7 @@ tolerations: []
 
 affinity: {}
 
+applicationYmlMountPath: /deployments/config
 applicationYML:
 
 hazelcast:

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -12,6 +12,7 @@ image:
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+args: []
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -123,7 +123,7 @@ tolerations: []
 
 affinity: {}
 
-applicationYmlMountPath: /deployments/config
+applicationYMLMountPath: /deployments/config
 applicationYML:
 
 hazelcast:


### PR DESCRIPTION
**Description**

- Make properties mount path configurable (needed for native image as other path)
- Bump app version to 1.5.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable options to set container startup arguments and the mount path for application configuration files during deployment.

- **Chores**
  - Updated chart and application versions to 1.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->