### PR TITLE
keine cpu limits

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 1.0.0
+version: 1.0.2
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://assets.muenchen.de/logos/itm/itm-logo-256.png
 sources:

--- a/charts/refarch-templates/README.md
+++ b/charts/refarch-templates/README.md
@@ -157,12 +157,11 @@ If you don't set those properties, those values will be used by default:
         cpu: 100m
         memory: 512Mi
       limits:
-        cpu: 500m
         memory: 512Mi
     replicas: 1
 ```
 
-> **Note:** You can also just override the `requests` or `limits`, but always need to set `cpu` and `memory` if you do so.
+> **Note:** You can also just override the `requests` or `limits`, but always need to set `cpu` and `memory` if you do so. You don't need to specifie the CPU-Limit in the new cluster. The pod takes all the availbe cpu of a node for a multithreating process.
 
 Configuring auto-scaling is optional and disabled by default (enabled by configuring the `autoscalling` block).
 

--- a/charts/refarch-templates/README.md
+++ b/charts/refarch-templates/README.md
@@ -161,7 +161,7 @@ If you don't set those properties, those values will be used by default:
     replicas: 1
 ```
 
-> **Note:** You can also just override the `requests` or `limits`, but always need to set `cpu` and `memory` if you do so. You don't need to specifie the CPU-Limit in the new cluster. The pod takes all the availbe cpu of a node for a multithreating process.
+> **Note:** You can also just override the `requests` or `limits` individually. If you do so, the defaults for both `cpu` and `memory` will not apply.
 
 Configuring auto-scaling is optional and disabled by default (enabled by configuring the `autoscalling` block).
 

--- a/charts/refarch-templates/templates/deployment.yaml
+++ b/charts/refarch-templates/templates/deployment.yaml
@@ -87,7 +87,6 @@ spec:
             {{- toYaml $module.resources | nindent 12 }}
             {{- else }}
             limits:
-              cpu: 500m
               memory: 512Mi
             {{- end }}
           {{- if $module.env }}


### PR DESCRIPTION
**Description**

im neuen cluster braucht man keine cpu limits mehr. es wird einfach genommen was auf dem knoten verfügbar ist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed the default CPU resource limit for containers; the memory limit remains unchanged.
  - Updated the application chart version to 1.0.2.
  - Clarified resource configuration documentation to reflect updated CPU limit handling and cluster behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->