### PR TITLE
chore(refarch-gateway): rm gc max metaspace size

### DIFF
--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.5.0
+version: 1.5.1
 appVersion: 1.5.0
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://assets.muenchen.de/logos/itm/itm-logo-256.png

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -107,8 +107,6 @@ volumeMounts: []
 
 # Additional env on the output Deployment definition.
 env:
-  - name: GC_MAX_METASPACE_SIZE
-    value: "200"
   - name: TZ
     value: Europe/Berlin
 


### PR DESCRIPTION
**Description**

It's best practice to define as few as possible JVM arguments.
Also the reason this was initially set is no longer correct (default limit of 100mb, actually now it is unlimited).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the environment variable GC_MAX_METASPACE_SIZE from the configuration settings.
  * Updated the application version to 1.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->