### PR TITLE
feat(refarch-gateway): add service monitor

### DIFF
--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.5.0
+version: 1.5.2
 appVersion: 1.5.0
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://assets.muenchen.de/logos/itm/itm-logo-256.png

--- a/charts/refarch-gateway/templates/service-monitor.yaml
+++ b/charts/refarch-gateway/templates/service-monitor.yaml
@@ -10,7 +10,7 @@ spec:
     - interval: {{ .Values.serviceMonitor.interval }}
       port: http
       scheme: http
-      path: /actuator/metrics
+      path: {{ .Values.serviceMonitor.path }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/refarch-gateway/templates/service-monitor.yaml
+++ b/charts/refarch-gateway/templates/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.enabled}}
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/refarch-gateway/templates/service-monitor.yaml
+++ b/charts/refarch-gateway/templates/service-monitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.enabled}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "refarch-gateway.fullname" . }}-monitor
+  labels:
+    {{- include "refarch-gateway.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - interval: 30s
+      port: http
+      scheme: http
+      path: /actuator/metrics
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "refarch-gateway.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/refarch-gateway/templates/service-monitor.yaml
+++ b/charts/refarch-gateway/templates/service-monitor.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "refarch-gateway.labels" . | nindent 4 }}
 spec:
   endpoints:
-    - interval: 30s
+    - interval: {{ .Values.serviceMonitor.interval }}
       port: http
       scheme: http
       path: /actuator/metrics

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -131,4 +131,5 @@ hazelcast:
 
 serviceMonitor:
   enabled: true
+  path: /actuator/metrics
   interval: 30s

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -130,6 +130,6 @@ hazelcast:
   assignRoleToServiceAccount: true
 
 serviceMonitor:
-  enabled: true
+  enabled: false
   path: /actuator/metrics
   interval: 30s

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -130,3 +130,6 @@ applicationYML:
 hazelcast:
   enabled: true
   assignRoleToServiceAccount: true
+
+serviceMonitor:
+  enabled: false

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -130,4 +130,5 @@ hazelcast:
   assignRoleToServiceAccount: true
 
 serviceMonitor:
-  enabled: false
+  enabled: true
+  interval: 30s


### PR DESCRIPTION
**Description**

Add ServiceMonitor to allow collection of prometheus metrics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional integration with Prometheus Operator by introducing a ServiceMonitor resource, configurable via a new setting.
* **Chores**
  * Updated the Helm chart version to 1.5.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->