### PR TITLE
[refarch-gateway] Bump gateway image to 1.6.0

### DIFF
--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.5.2
-appVersion: 1.5.0
+version: 1.6.0
+appVersion: 1.6.0
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://assets.muenchen.de/logos/itm/itm-logo-256.png
 sources:


### PR DESCRIPTION
**Description**

- Bumped refarch-gateway to 1.6.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart and application version for refarch-gateway to 1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->