### PR TITLE
[refarch-templates] Bump gateway chart to 1.6.0

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 1.0.7
+version: 1.0.8
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://assets.muenchen.de/logos/itm/itm-logo-256.png
 dependencies:
   - name: refarch-gateway
     condition: refarch-gateway.enable
-    version: 1.5.0
+    version: 1.6.0
     repository: "@it-at-m"
 sources:
   - "https://github.com/it-at-m/helm-charts"

--- a/charts/refarch-templates/values-example.yaml
+++ b/charts/refarch-templates/values-example.yaml
@@ -112,36 +112,38 @@ refarch-gateway:
     spring:
       cloud:
         gateway:
-          routes:
-            - id: "sso"
-              uri: $SSO_URL
-              predicates:
-                - "Path=/api/sso/userinfo"
-              filters:
-                - "RewritePath=/api/sso/userinfo, /auth/realms/${SSO_REALM}/protocol/openid-connect/userinfo"
-            - id: "webcomponent"
-              uri: "http://myrelease-webcomponent:8080/"
-              predicates:
-                - "Path=/public/webcomponent"
-              filters:
-                - "RewritePath=/public/webcomponent/(?<urlsegments>.*), /$\\{urlsegments}"
-            - id: "backend"
-              uri: "http://myrelease-backend:8080/"
-              predicates:
-                - "Path=/api/refarch-backend/**"
-              filters:
-                - "RewritePath=/api/refarch-backend/(?<urlsegments>.*), /$\\{urlsegments}"
-            - id: "eai"
-              uri: "http://myrelease-eai:8080/"
-              predicates:
-                - "Path=/api/refarch-eai/**"
-              filters:
-                - "RewritePath=/api/refarch-eai/(?<urlsegments>.*), /$\\{urlsegments}"
-            # The catch all route needs to be stand at the end.
-            - id: "frontend"
-              uri: "http://myrelease-frontend:8080/"
-              predicates:
-                - "Path=/**"
+          server:
+            webflux:
+              routes:
+                - id: "sso"
+                  uri: $SSO_URL
+                  predicates:
+                    - "Path=/api/sso/userinfo"
+                  filters:
+                    - "RewritePath=/api/sso/userinfo, /auth/realms/${SSO_REALM}/protocol/openid-connect/userinfo"
+                - id: "webcomponent"
+                  uri: "http://myrelease-webcomponent:8080/"
+                  predicates:
+                    - "Path=/public/webcomponent"
+                  filters:
+                    - "RewritePath=/public/webcomponent/(?<urlsegments>.*), /$\\{urlsegments}"
+                - id: "backend"
+                  uri: "http://myrelease-backend:8080/"
+                  predicates:
+                    - "Path=/api/refarch-backend/**"
+                  filters:
+                    - "RewritePath=/api/refarch-backend/(?<urlsegments>.*), /$\\{urlsegments}"
+                - id: "eai"
+                  uri: "http://myrelease-eai:8080/"
+                  predicates:
+                    - "Path=/api/refarch-eai/**"
+                  filters:
+                    - "RewritePath=/api/refarch-eai/(?<urlsegments>.*), /$\\{urlsegments}"
+                # The catch all route needs to be stand at the end.
+                - id: "frontend"
+                  uri: "http://myrelease-frontend:8080/"
+                  predicates:
+                    - "Path=/**"
   ingress:
     enabled: true
     hosts:


### PR DESCRIPTION
**Description**

- Bumped gateway chart dependency to 1.6.0

**Reference**

Issues #XXX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart and dependency versions for refarch-templates and refarch-gateway.

* **Refactor**
  * Restructured the example configuration for Spring Cloud Gateway routes, introducing an additional nesting level for improved organization. No changes to the actual route definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->