### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Lint and Test Charts
 on: pull_request
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/helm-charts/security/code-scanning/1](https://github.com/it-at-m/helm-charts/security/code-scanning/1)

To fix the problem, an explicit `permissions` block should be added to the workflow at the root level. This block will minimize the `GITHUB_TOKEN` permissions to only those required for the operations in the workflow. From the provided workflow, it appears that the workflow interacts with repository contents (e.g., fetching the repository branch and performing operations with Helm). Therefore, the `contents: read` permission is sufficient. Write permissions are not necessary based on the provided steps.

The `permissions` block should be added after the workflow name and before the `on` block. This ensures that the permissions apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->