### PR TITLE
add ingress labels for the new cluster

### DIFF
--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.6.1
+version: 1.6.2
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://assets.muenchen.de/logos/itm/itm-logo-256.png
 sources:

--- a/charts/refarch-gateway/templates/ingress.yaml
+++ b/charts/refarch-gateway/templates/ingress.yaml
@@ -18,6 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "refarch-gateway.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -53,8 +53,8 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   # If your ingress controller auto-creates a Route, set these labels only on the first rollout.
   # Otherwise, delete the Route manually before reapplying.
-  labels:
-    type: web2tier  # or eai
+  labels:  {}
+    # type: web2tier  # or eai
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -53,7 +53,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   # If your ingress controller auto-creates a Route, set these labels only on the first rollout.
   # Otherwise, delete the Route manually before reapplying.
-  labels:  {}
+  labels: {}
     # type: web2tier  # or eai
   hosts:
     - host: chart-example.local

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -51,7 +51,8 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-# if your ingress creates a route, then you can set it only at the first rollout. Otherwise you need to delete manual the route.
+  # If your ingress controller auto-creates a Route, set these labels only on the first rollout.
+  # Otherwise, delete the Route manually before reapplying.
   labels:
     type: web2tier  # or eai
   hosts:

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -52,7 +52,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   labels:
-    type: web2tier # or eai
+    type: web2tier  # or eai
   hosts:
     - host: chart-example.local
       paths:

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -51,6 +51,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+# if your ingress creates a route, then you can set it only at the first rollout. Otherwise you need to delete manual the route.
   labels:
     type: web2tier  # or eai
   hosts:

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -51,6 +51,8 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  labels:
+    type: web2tier # or eai
   hosts:
     - host: chart-example.local
       paths:


### PR DESCRIPTION
**Description**

add ingress labels for the new cluster


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional Ingress labels can be configured to add custom metadata to Ingress resources; no change when unset.

- **Chores**
  - Helm chart version bumped to 1.6.2.

- **Documentation**
  - Added a commented example ingress label in chart values to illustrate usage (no active default value).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->