### PR TITLE
[java-spring-boot] add routes[].extraLabels to example in default values.yaml

### DIFF
--- a/charts/java-spring-boot/Chart.yaml
+++ b/charts/java-spring-boot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: java-spring-boot
 description: Generic Helm chart to deploy a Spring Boot application on Kubernetes
 type: application
-version: 1.0.0
+version: 1.0.1
 maintainers:
   - name: eidottermihi
     email: eidottermihi@gmail.com

--- a/charts/java-spring-boot/values.yaml
+++ b/charts/java-spring-boot/values.yaml
@@ -225,6 +225,8 @@ routes:
   #   annotations:
   #     haproxy.router.openshift.io/timeout: "30s"
   #     haproxy.router.openshift.io/ip_whitelist: "X.X.X.X Y.Y.Y.Y"
+  #   extraLabels:
+  #     type: "eai"
   #   tls:
   #     termination: "Edge"
   #     insecureEdgeTerminationPolicy: "Redirect"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Released a patch update of the Java Spring Boot Helm chart to version 1.0.1.

* Documentation
  * Added commented examples for extra route labels in the Helm values to guide configuration without changing defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->