### PR TITLE
[refarch-templates] Bump gateway chart to 1.7.0

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 1.1.3
+version: 1.1.4
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:
   - name: refarch-gateway
     condition: refarch-gateway.enabled
-    version: 1.6.3
+    version: 1.7.0
     repository: "@it-at-m"
 sources:
   - "https://github.com/it-at-m/helm-charts"


### PR DESCRIPTION
**Description**

# Changes
- Bump refarch-gateway chart dependency to 1.7.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Bumped template chart version to 1.1.4.
  - Updated gateway component dependency to 1.7.0 for alignment with the latest release.
  - No user-facing behavior changes expected; installs will use the updated gateway version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->