### PR TITLE
fix(refarch-gateway): OOMKill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
           check-latest: true
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
+        with:
+          # Workaround as default 4.0.4 doesn't work with python 3.14
+          # See https://github.com/helm/chart-testing-action/issues/177
+          yamale_version: "6.0.0"
       - name: Add dependency repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami

--- a/charts/refarch-gateway/Chart.yaml
+++ b/charts/refarch-gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-gateway
 description: Helm chart for deploying the it@M refarch-gateway
 type: application
-version: 1.7.0
+version: 1.7.1
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 sources:

--- a/charts/refarch-gateway/README.md
+++ b/charts/refarch-gateway/README.md
@@ -1,13 +1,3 @@
 # RefArch gateway chart
 
 Helm chart for the [refarch-gateway](https://github.com/it-at-m/refarch).
-
-## Configuration
-
-### Memory limit change
-
-**Warning:** When `resources.limit.memory` is changed, `javaHeapMaxMemRatio` (mapped to `JAVA_MAX_MEM_RATIO`) needs to 
-modified accordingly.
-
-The default value of `javaHeapMaxMemRatio=30` is intended for the default `resource.limit.memory=500m`.
-See [documentation of env var `JAVA_MAX_MEM_RATIO`](https://rh-openjdk.github.io/redhat-openjdk-containers/ubi9/ubi9-openjdk-21-runtime.html).

--- a/charts/refarch-gateway/README.md
+++ b/charts/refarch-gateway/README.md
@@ -9,5 +9,5 @@ Helm chart for the [refarch-gateway](https://github.com/it-at-m/refarch).
 **Warning:** When `resources.limit.memory` is changed, `javaHeapMaxMemRatio` (mapped to `JAVA_MAX_MEM_RATIO`) needs to 
 modified accordingly.
 
-The default value of `javaHeapMaxMemRatio=30` is intended for the default `resource.limit.memory=500m`.
+The default value of `javaHeapMaxMemRatio=30` is intended for the default `resources.limit.memory=500m`.
 See [documentation of env var `JAVA_MAX_MEM_RATIO`](https://rh-openjdk.github.io/redhat-openjdk-containers/ubi9/ubi9-openjdk-21-runtime.html).

--- a/charts/refarch-gateway/README.md
+++ b/charts/refarch-gateway/README.md
@@ -6,8 +6,8 @@ Helm chart for the [refarch-gateway](https://github.com/it-at-m/refarch).
 
 ### Memory limit change
 
-**Warning:** When `resources.limit.memory` is changed, `javaHeapMaxMemRatio` (mapped to `JAVA_MAX_MEM_RATIO`) needs to 
-modified accordingly.
+**Warning:** When `resources.limit.memory` is changed, `javaHeapMaxMemRatio` (mapped to `JAVA_MAX_MEM_RATIO`) needs to
+be modified accordingly.
 
 The default value of `javaHeapMaxMemRatio=30` is intended for the default `resources.limit.memory=500m`.
 See [documentation of env var `JAVA_MAX_MEM_RATIO`](https://rh-openjdk.github.io/redhat-openjdk-containers/ubi9/ubi9-openjdk-21-runtime.html).

--- a/charts/refarch-gateway/README.md
+++ b/charts/refarch-gateway/README.md
@@ -1,3 +1,13 @@
 # RefArch gateway chart
 
 Helm chart for the [refarch-gateway](https://github.com/it-at-m/refarch).
+
+## Configuration
+
+### Memory limit change
+
+**Warning:** When `resources.limit.memory` is changed, `javaHeapMaxMemRatio` (mapped to `JAVA_MAX_MEM_RATIO`) needs to 
+modified accordingly.
+
+The default value of `javaHeapMaxMemRatio=30` is intended for the default `resource.limit.memory=500m`.
+See [documentation of env var `JAVA_MAX_MEM_RATIO`](https://rh-openjdk.github.io/redhat-openjdk-containers/ubi9/ubi9-openjdk-21-runtime.html).

--- a/charts/refarch-gateway/templates/deployment.yaml
+++ b/charts/refarch-gateway/templates/deployment.yaml
@@ -65,6 +65,8 @@ spec:
             {{- if gt (len .Values.envAppend) 0 }}
             {{- tpl (toYaml .Values.envAppend) . | nindent 12 }}
             {{- end}}
+            - name: JAVA_MAX_MEM_RATIO
+              value: {{ .Values.javaHeapMaxMemRatio | quote }}
             {{- if .Values.hazelcast.enabled }}
             - name: HAZELCAST_JAVA_OPTS_APPEND
               value: "--add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"

--- a/charts/refarch-gateway/templates/deployment.yaml
+++ b/charts/refarch-gateway/templates/deployment.yaml
@@ -59,12 +59,6 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-            {{- if gt (len .Values.env) 0 }}
-            {{- tpl (toYaml .Values.env) . | nindent 12 }}
-            {{- end}}
-            {{- if gt (len .Values.envAppend) 0 }}
-            {{- tpl (toYaml .Values.envAppend) . | nindent 12 }}
-            {{- end}}
             - name: JAVA_MAX_MEM_RATIO
               value: {{ .Values.javaHeapMaxMemRatio | quote }}
             {{- if .Values.hazelcast.enabled }}
@@ -73,6 +67,12 @@ spec:
             - name: REFARCH_HAZELCAST_SERVICENAME
               value: {{ include "refarch-gateway.fullname" . }}
             {{- end }}
+            {{- if gt (len .Values.env) 0 }}
+            {{- tpl (toYaml .Values.env) . | nindent 12 }}
+            {{- end}}
+            {{- if gt (len .Values.envAppend) 0 }}
+            {{- tpl (toYaml .Values.envAppend) . | nindent 12 }}
+            {{- end}}
           {{- if .Values.envFrom }}
           envFrom:
             {{- toYaml .Values.envFrom | nindent 12 }}

--- a/charts/refarch-gateway/templates/deployment.yaml
+++ b/charts/refarch-gateway/templates/deployment.yaml
@@ -65,8 +65,6 @@ spec:
             {{- if gt (len .Values.envAppend) 0 }}
             {{- tpl (toYaml .Values.envAppend) . | nindent 12 }}
             {{- end}}
-            - name: JAVA_MAX_MEM_RATIO
-              value: {{ .Values.javaHeapMaxMemRatio | quote }}
             {{- if .Values.hazelcast.enabled }}
             - name: HAZELCAST_JAVA_OPTS_APPEND
               value: "--add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -77,9 +77,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# Must be changed when resources.limits.memory is changed
-javaHeapMaxMemRatio: 30
-
 startupProbe:
   httpGet:
     path: /actuator/health

--- a/charts/refarch-gateway/values.yaml
+++ b/charts/refarch-gateway/values.yaml
@@ -77,6 +77,9 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# Must be changed when resources.limits.memory is changed
+javaHeapMaxMemRatio: 30
+
 startupProbe:
   httpGet:
     path: /actuator/health


### PR DESCRIPTION
**Description**

Fix gateway OOMKill through OpenShift because of too much Heap usage, by setting env var `JAVA_MAX_MEM_RATIO=30` by default.

**WARNING:** Can collide with env var `JAVA_MAX_MEM_RATIO` configured through `env, envAppend`. In that case the last defined one takes precedence which is the user defined one.

**Reference**

Issues https://git.muenchen.de/openshift/projects/-/issues/186#note_1035794
Blocked by CI fix with PR https://github.com/it-at-m/helm-charts/pull/193


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add configurable Java heap max memory ratio (default 30) and expose it via an environment variable for JVM tuning.
  * Improve startup probe by specifying HTTP port and adding a 60s initial delay for more reliable startups.

* **Documentation**
  * Add guidance on adjusting memory limits and corresponding heap ratio, including cautions and reference links.

* **Chores**
  * Bump chart version to 1.7.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->