### PR TITLE
fix(ci/helm-lint): chart-testing not working with python 3.14 by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
           check-latest: true
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
+        with:
+          # Workaround as default 4.0.4 doesn't work with python 3.14
+          # See https://github.com/helm/chart-testing-action/issues/177
+          yamale_version: "6.0.0"
       - name: Add dependency repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami


### PR DESCRIPTION
**Description**

Fix CI `chart-testing-action` by using specific `yamale` version `6.0.0`, because default `4.0.4` isn't compatible with python 3.14.

**Reference**

Issues https://github.com/helm/chart-testing-action/issues/177


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration workflow to pin a specific version of a chart validation tool used during testing.
  - Ensures consistent behavior in automated checks across environments.

- **Notes**
  - No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->