### PR TITLE
chore(refarch-templates): bump gateway to 1.7.1

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:
   - name: refarch-gateway
     condition: refarch-gateway.enabled
-    version: 1.7.0
+    version: 1.7.1
     repository: "@it-at-m"
 sources:
   - "https://github.com/it-at-m/helm-charts"

--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 1.1.4
+version: 1.1.5
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:


### PR DESCRIPTION
**Description**

Bump refarch-templates gateway chart reference to 1.7.1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chart version to 1.1.5
  * Updated gateway dependency to version 1.7.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->