### PR TITLE
keycloak.postgresql.image.repository.bitnamilegacy/postgresql #185

### DIFF
--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.0.17
+version: 0.0.18
 appVersion: "v1.0.0"
 maintainers:
   - name: gislab-augsburg

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -347,12 +347,11 @@ postgresql:
 keycloak:
   postgresql:
     nameOverride: keycloak-postgresql
-  # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
-  image:
-    repository: bitnamilegacy/keycloak
-  postgresql:
+    # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
     image:
       repository: bitnamilegacy/postgresql
+  image:
+    repository: bitnamilegacy/keycloak
   global:
     security:
       allowInsecureImages: true

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -350,6 +350,9 @@ keycloak:
   # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
   image:
     repository: bitnamilegacy/keycloak
+  postgresql:
+    image:
+      repository: bitnamilegacy/postgresql
   global:
     security:
       allowInsecureImages: true


### PR DESCRIPTION
**Description**

the bitnami/keycloak chart includes PostgreSQL—and currently still uses the default image from the chart.

**Reference**

Issues #185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration to specify a separate PostgreSQL image for Keycloak deployments, enabling use of legacy or alternate image variants.

* **Chores**
  * Chart version bumped to 0.0.18.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->