### PR TITLE
App version 2.1.1

### DIFF
--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,8 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.0.19
-appVersion: "v1.0.0"
+version: 0.1.0
 maintainers:
   - name: klml
     email: klml@muenchen.de

--- a/charts/dave/charts/admin-portal/Chart.yaml
+++ b/charts/dave/charts/admin-portal/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: admin-portal
 description: DAVe traffic counting plattform, admin-portal
 type: application
-version: 0.0.14
-appVersion: "v1.0.0"
+version: 0.1.0
+appVersion: "2.1.1"
 maintainers:
   - name: gislab-augsburg
     email: martymcfly333@gmail.com

--- a/charts/dave/charts/admin-portal/Chart.yaml
+++ b/charts/dave/charts/admin-portal/Chart.yaml
@@ -5,8 +5,6 @@ type: application
 version: 0.1.0
 appVersion: "2.1.1"
 maintainers:
-  - name: gislab-augsburg
-    email: martymcfly333@gmail.com
   - name: klml
     email: klml@muenchen.de
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/dave/charts/admin-portal

--- a/charts/dave/charts/admin-portal/values.yaml
+++ b/charts/dave/charts/admin-portal/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/it-at-m/dave-admin-portal/dave-adminportal
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.1.1"
+  # tag: "1.1.1"
 
 imagePullSecrets: []
 # nameOverride: ""

--- a/charts/dave/charts/backend/Chart.yaml
+++ b/charts/dave/charts/backend/Chart.yaml
@@ -5,8 +5,6 @@ type: application
 version: 0.1.0
 appVersion: "2.1.1"
 maintainers:
-  - name: gislab-augsburg
-    email: martymcfly333@gmail.com
   - name: klml
     email: klml@muenchen.de
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/dave/charts/backend

--- a/charts/dave/charts/backend/Chart.yaml
+++ b/charts/dave/charts/backend/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: backend
 description: DAVe traffic counting plattform, backend
 type: application
-version: 0.0.14
-appVersion: "v2.1.1"
+version: 0.1.0
+appVersion: "2.1.1"
 maintainers:
   - name: gislab-augsburg
     email: martymcfly333@gmail.com

--- a/charts/dave/charts/backend/values.yaml
+++ b/charts/dave/charts/backend/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/it-at-m/dave-backend/dave-backend
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.1.1"
+  # tag: "1.1.1"
 
 imagePullSecrets: []
 # nameOverride: ""

--- a/charts/dave/charts/eai/Chart.yaml
+++ b/charts/dave/charts/eai/Chart.yaml
@@ -5,8 +5,6 @@ type: application
 version: 0.1.0
 appVersion: "2.1.1"
 maintainers:
-  - name: gislab-augsburg
-    email: martymcfly333@gmail.com
   - name: klml
     email: klml@muenchen.de
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/dave/charts/eai

--- a/charts/dave/charts/eai/Chart.yaml
+++ b/charts/dave/charts/eai/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: eai
 description: DAVe traffic counting plattform, eai
 type: application
-version: 0.0.14
-appVersion: "v1.0.0"
+version: 0.1.0
+appVersion: "2.1.1"
 maintainers:
   - name: gislab-augsburg
     email: martymcfly333@gmail.com

--- a/charts/dave/charts/eai/values.yaml
+++ b/charts/dave/charts/eai/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/it-at-m/dave-eai/dave-eai
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.1.1"
+  # tag: "1.1.1"
 
 imagePullSecrets: []
 # nameOverride: ""

--- a/charts/dave/charts/frontend/Chart.yaml
+++ b/charts/dave/charts/frontend/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: frontend
 description: DAVe traffic counting plattform, frontend
 type: application
-version: 0.0.14
-appVersion: "v1.0.0"
+version: 0.1.0
+appVersion: "2.1.1"
 maintainers:
   - name: gislab-augsburg
     email: martymcfly333@gmail.com

--- a/charts/dave/charts/frontend/Chart.yaml
+++ b/charts/dave/charts/frontend/Chart.yaml
@@ -5,8 +5,6 @@ type: application
 version: 0.1.0
 appVersion: "2.1.1"
 maintainers:
-  - name: gislab-augsburg
-    email: martymcfly333@gmail.com
   - name: klml
     email: klml@muenchen.de
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/dave/charts/frontend

--- a/charts/dave/charts/frontend/values.yaml
+++ b/charts/dave/charts/frontend/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/it-at-m/dave-frontend/dave-frontend
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.1.1"
+  # tag: "1.1.1"
 
 imagePullSecrets: []
 # nameOverride: ""

--- a/charts/dave/charts/selfservice-portal/Chart.yaml
+++ b/charts/dave/charts/selfservice-portal/Chart.yaml
@@ -5,8 +5,6 @@ type: application
 version: 0.1.0
 appVersion: "2.1.1"
 maintainers:
-  - name: gislab-augsburg
-    email: martymcfly333@gmail.com
   - name: klml
     email: klml@muenchen.de
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/dave/charts/selfservice-portal

--- a/charts/dave/charts/selfservice-portal/Chart.yaml
+++ b/charts/dave/charts/selfservice-portal/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: selfservice-portal
 description: DAVe traffic counting plattform, selfservice-portal
 type: application
-version: 0.0.14
-appVersion: "v1.0.0"
+version: 0.1.0
+appVersion: "2.1.1"
 maintainers:
   - name: gislab-augsburg
     email: martymcfly333@gmail.com

--- a/charts/dave/charts/selfservice-portal/values.yaml
+++ b/charts/dave/charts/selfservice-portal/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/it-at-m/dave-selfservice-portal/dave-selfserviceportal
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2.1.1"
+  # tag: "1.1.1"
 
 imagePullSecrets: []
 # nameOverride: ""


### PR DESCRIPTION
**Description**

* app version instead of tags
* rm gislab-augsburg

# 185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart versions to 0.1.0 across the charts.
  * Updated application versions to 2.1.1 for admin-portal, backend, EAI, frontend, and selfservice-portal.
  * Simplified maintainer listings (removed outdated entries; remaining maintainer retained).
  * Removed explicit image tag overrides in values, relying on chart/app defaults instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->