### PR TITLE
Support deployment strategy recreate.

### DIFF
--- a/charts/java-spring-boot/Chart.yaml
+++ b/charts/java-spring-boot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: java-spring-boot
 description: Generic Helm chart to deploy a Spring Boot application on Kubernetes
 type: application
-version: 1.0.4
+version: 1.0.5
 maintainers:
   - name: eidottermihi
     email: eidottermihi@gmail.com

--- a/charts/java-spring-boot/ci/test-deployment-strategy-recreate-values.yaml
+++ b/charts/java-spring-boot/ci/test-deployment-strategy-recreate-values.yaml
@@ -1,0 +1,17 @@
+# use appswitcher-server for testing
+image:
+  repository: "ghcr.io/it-at-m/appswitcher-server"
+  tag: "1.2.1"
+
+deploymentStrategy:
+  type: Recreate
+
+applicationYml: |-
+  applications:
+    google:
+      display-name: Google
+      url: https://google.com
+      image-url: https://www.google.com/favicon.ico
+      tags:
+        - global
+      sort-order: 20

--- a/charts/java-spring-boot/values.yaml
+++ b/charts/java-spring-boot/values.yaml
@@ -12,7 +12,7 @@ revisionHistoryLimit: 10
 # see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 deploymentStrategy:
   type: RollingUpdate
-  rollingUpdate: {}
+  # rollingUpdate: {}
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:


### PR DESCRIPTION
**Description**

Support deployment strategy `Recreate`.

**Reference**

Issues #219 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated chart version to 1.0.5.

* **New Features**
  * Added new test deployment configuration with support for Recreate deployment strategy and application metadata.

* **Updates**
  * Modified deployment strategy configuration to disable rolling update by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->