### PR TITLE
refact(refarch-templates)!: modules as dict instead of array

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 1.1.7
+version: 2.0.0
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:

--- a/charts/refarch-templates/README.md
+++ b/charts/refarch-templates/README.md
@@ -120,14 +120,14 @@ Further configuration option can be seen in the documentation of the [API-Gatewa
 
 ### Module configurations
 
-Modules consist of individual components in an array.
+Modules consist of individual components in a dict.
 Each module consist of individuell Kubernetes resources (e.g. Deployment, Service, HPA, ...).
 All configuration options need to be inside a `module`.
 
 Example:
 ```yaml
   modules:
-    # add your modules configuration here (as a list)
+    # add your modules configuration here (as a dict)
 ```
 
 #### Base information
@@ -137,7 +137,7 @@ Additionally, you can override the `pullPolicy`, which is set to `IfNotPresent` 
 
 Example:
 ```yaml
-    - name: frontend
+    frontend:
       image:
         registry: ghcr.io
         repository: it-at-m/refarch-templates/refarch-frontend

--- a/charts/refarch-templates/README.md
+++ b/charts/refarch-templates/README.md
@@ -121,7 +121,7 @@ Further configuration option can be seen in the documentation of the [API-Gatewa
 ### Module configurations
 
 Modules consist of individual components in a dict.
-Each module consist of individuell Kubernetes resources (e.g. Deployment, Service, HPA, ...).
+Each module consists of individual Kubernetes resources (e.g., Deployment, Service, HPA, ...).
 All configuration options need to be inside a `module`.
 
 Example:

--- a/charts/refarch-templates/ci/test-values.yaml
+++ b/charts/refarch-templates/ci/test-values.yaml
@@ -1,12 +1,12 @@
 modules:
-  - name: frontend
+  frontend:
     image:
       registry: ghcr.io
       repository: it-at-m/refarch-templates/refarch-frontend
       tag: "latest"
     service:
       http: true
-  - name: webcomponent
+  webcomponent:
     image:
       registry: ghcr.io
       repository: it-at-m/refarch-templates/refarch-webcomponent
@@ -25,7 +25,7 @@ modules:
 #          active: "no-security"
 #    service:
 #      http: true
-  - name: eai
+  eai:
     image:
       registry: ghcr.io
       repository: it-at-m/refarch-templates/refarch-eai

--- a/charts/refarch-templates/templates/_helpers.tpl
+++ b/charts/refarch-templates/templates/_helpers.tpl
@@ -10,7 +10,7 @@ Get the truncated module name #backend
 Get the truncated module name with the release name #dev-backend
 */}}
 {{- define "getFullname" -}}
-{{- $moduleName := .module.name }}
+{{- $moduleName := .moduleName }}
 {{- printf "%s-%s" .dot.Release.Name $moduleName | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -34,7 +34,7 @@ Get the truncated chart name
 Get the Common labels
 */}}
 {{- define "getLabels" -}}
-{{- $moduleName := .module.name }}
+{{- $moduleName := .moduleName }}
 helm.sh/chart: {{ include "getChartName" .dot }}
 {{- include "getSelectorLabels" . }}
 {{- if ".Chart.Version" }}
@@ -47,7 +47,7 @@ app.kubernetes.io/managed-by: {{ .dot.Release.Service }}
 Get the Selector labels for connection between service and pods
 */}}
 {{- define "getSelectorLabels" -}}
-{{- $moduleName := .module.name }}
+{{- $moduleName := .moduleName }}
 {{- if $moduleName }}
 app.kubernetes.io/name: {{ include "getName" $moduleName }}
 {{- end }}

--- a/charts/refarch-templates/templates/config-map-application-yml.yaml
+++ b/charts/refarch-templates/templates/config-map-application-yml.yaml
@@ -1,6 +1,6 @@
 {{- $dot := . }}
-{{- range $module := .Values.modules -}}
-{{ $data := dict "dot" $dot "module" $module }}
+{{- range $moduleName, $module := .Values.modules -}}
+{{ $data := dict "dot" $dot "module" $module "moduleName" $moduleName }}
 {{ if $module.applicationYML }}
 {{ $checksum := $module.applicationYML | toYaml | sha256sum | trunc 64 }}
 ---

--- a/charts/refarch-templates/templates/deployment.yaml
+++ b/charts/refarch-templates/templates/deployment.yaml
@@ -1,6 +1,6 @@
 {{- $dot := . }}
-{{- range $module := .Values.modules -}}
-{{ $data := dict "dot" $dot "module" $module }}
+{{- range $moduleName, $module := .Values.modules -}}
+{{ $data := dict "dot" $dot "module" $module "moduleName" $moduleName }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -37,7 +37,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ $module.name }}
+        - name: {{ $moduleName }}
           securityContext:
             capabilities:
               drop:

--- a/charts/refarch-templates/templates/hpa.yaml
+++ b/charts/refarch-templates/templates/hpa.yaml
@@ -1,6 +1,6 @@
 {{- $dot := . }}
-{{- range $module := .Values.modules -}}
-{{ $data := dict "dot" $dot "module" $module }}
+{{- range $moduleName, $module := .Values.modules -}}
+{{ $data := dict "dot" $dot "module" $module "moduleName" $moduleName }}
 {{- if $module.autoscaling }}
 {{- if or $module.autoscaling.targetCPUUtilizationPercentage $module.autoscaling.targetMemoryUtilizationPercentage }}
 ---
@@ -14,7 +14,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ $module.name }}
+    name: {{ $moduleName }}
   minReplicas: {{ $module.autoscaling.minReplicas | default 1 }}
   maxReplicas: {{ $module.autoscaling.maxReplicas }}
   metrics:

--- a/charts/refarch-templates/templates/image-stream.yml
+++ b/charts/refarch-templates/templates/image-stream.yml
@@ -7,12 +7,12 @@ spec:
   lookupPolicy:
     local: false
   tags:
-  {{- range .Values.modules }}
-    - name: {{.name}}
+  {{- range $moduleName, $module := .Values.modules }}
+    - name: {{ $moduleName }}
       annotations: {}
       from:
         kind: DockerImage
-        name: {{.image.registry}}/{{.image.repository}}:{{.image.tag}}
+        name: {{ $module.image.registry }}/{{ $module.image.repository }}:{{ $module.image.tag }}
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/charts/refarch-templates/templates/ingress.yaml
+++ b/charts/refarch-templates/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- $dot := . }}
-{{- range $module := .Values.modules -}}
-{{ $data := dict "dot" $dot "module" $module }}
+{{- range $moduleName, $module := .Values.modules -}}
+{{ $data := dict "dot" $dot "module" $module "moduleName" $moduleName }}
 {{- if $module.ingress -}}
 ---
 apiVersion: networking.k8s.io/v1

--- a/charts/refarch-templates/templates/service-monitor.yaml
+++ b/charts/refarch-templates/templates/service-monitor.yaml
@@ -1,6 +1,6 @@
 {{- $dot := . }}
-{{- range $module := .Values.modules -}}
-{{ $data := dict "dot" $dot "module" $module }}
+{{- range $moduleName, $module := .Values.modules -}}
+{{ $data := dict "dot" $dot "module" $module "moduleName" $moduleName }}
 {{- if and  $module.serviceMonitor $module.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/charts/refarch-templates/templates/service.yaml
+++ b/charts/refarch-templates/templates/service.yaml
@@ -1,6 +1,6 @@
 {{- $dot := . }}
-{{- range $module := .Values.modules -}}
-{{ $data := dict "dot" $dot "module" $module }}
+{{- range $moduleName, $module := .Values.modules -}}
+{{ $data := dict "dot" $dot "module" $module "moduleName" $moduleName }}
 {{- if $module.service }}
 ---
 apiVersion: v1

--- a/charts/refarch-templates/templates/tests/test-connection.yaml
+++ b/charts/refarch-templates/templates/tests/test-connection.yaml
@@ -1,6 +1,6 @@
 {{- $dot := . }}
-{{- range $module := .Values.modules -}}
-{{ $data := dict "dot" $dot "module" $module }}
+{{- range $moduleName, $module := .Values.modules -}}
+{{ $data := dict "dot" $dot "module" $module "moduleName" $moduleName }}
 ---
 apiVersion: v1
 kind: Pod

--- a/charts/refarch-templates/values-example.yaml
+++ b/charts/refarch-templates/values-example.yaml
@@ -26,7 +26,7 @@ secrets:
       - PASSWORD
 # Module-specific configuration
 modules:
-  - name: frontend
+  frontend:
     image:
       # Please don't use the tag latest, because every time the image is updated you need to restart the pod.
       # In Openshift you can use the ImageStreamTrigger. https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes
@@ -36,7 +36,7 @@ modules:
       tag: "0.0.1"
     service:
       http: true
-  - name: webcomponent
+  webcomponent:
     image:
       # Please don't use the tag latest, because every time the image is updated you need to restart the pod.
       # In Openshift you can use the ImageStreamTrigger. https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes
@@ -46,7 +46,7 @@ modules:
       tag: "latest"
     service:
       http: true
-  - name: backend
+  backend:
     image:
       # Please don't use the tag latest, because every time the image is updated you need to restart the pod.
       # In Openshift you can use the ImageStreamTrigger. https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes
@@ -77,11 +77,11 @@ modules:
         value: "Europe/Berlin"
     service:
       http: true
-    volumes: 
-     - *cacertsVolume
-    volumeMounts: 
-     - *cacertsVolumeMount
-  - name: eai
+    volumes:
+      - *cacertsVolume
+    volumeMounts:
+      - *cacertsVolumeMount
+  eai:
     image:
       # Please don't use the tag latest, because every time the image is updated you need to restart the pod.
       # In Openshift you can use the ImageStreamTrigger. https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes
@@ -91,8 +91,10 @@ modules:
       tag: "latest"
     service:
       http: true
-    volumes: *cacertsVolume
-    volumeMounts: *cacertsVolumeMount
+    volumes:
+      - *cacertsVolume
+    volumeMounts:
+      - *cacertsVolumeMount
 
 # Sample Gateway configuration, which is enabled by default. For further configuration option view the chart dependency on https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway
 refarch-gateway:

--- a/charts/refarch-templates/values.yaml
+++ b/charts/refarch-templates/values.yaml
@@ -8,7 +8,7 @@ secrets: []
 imagePullSecrets: []
 
 # Configuration of Modules
-modules: []
+modules: {}
 
 # Configuration of ImageStream
 imageStream:


### PR DESCRIPTION
**Description**

- refarch-templates: refactor modules to dict instead of array
  - allows using multiple value files (e.g. base values.yaml and additional values per env)

**⚠️ Blocked by https://github.com/it-at-m/helm-charts/pull/239**

- [ ] Communicate upcoming breaking change
- [ ] Document migration in README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped chart version to 2.0.0.

* **Documentation**
  * Updated docs and examples to show module configuration as a mapping/dictionary instead of a list; corrected wording and examples.

* **Refactor**
  * Templates and example values now iterate modules by name (key) and expose module names for resource naming and labels — update your values to the mapping format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->