### PR TITLE
:memo: updated documentation by rearranging

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 1.1.9
+version: 1.1.10
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:

--- a/charts/refarch-templates/README.md
+++ b/charts/refarch-templates/README.md
@@ -118,6 +118,16 @@ refarch-gateway:
 ```
 Further configuration option can be seen in the documentation of the [API-Gateway](https://refarch.oss.muenchen.de/gateway.html).
 
+#### Autorollout (works only on OpenShift)
+
+This feature is ideal for development, so you don't need to update the chart each time. The image tag is linked, for example, to `latest`. Each time the tag gets overridden, a new rollout is triggered ([see also](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes)).
+
+```yaml
+imageStream:
+  enabled: true
+  name: stream
+```
+
 ### Module configurations
 
 Modules consist of individual components in an array.
@@ -339,25 +349,11 @@ The following configuration is picked up by default:
 > **Note:**: Those defaults are suitable for Spring-based applications, because applications like `refarch-backend` or `refarch-eai` expose those endpoints via Spring Actuator.
 Web components like `refarch-frontend` or `refarch-webcomponent` are compatible as well, as those mimic the actuator API
 
-#### Autorollout (works only on OpenShift)
-
-This feature is ideal for development, so you don't need to update the chart each time. The image tag is linked, for example, to `latest`. Each time the tag gets overridden, a new rollout is triggered.
-
-[details](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes)
-
-```yaml
-imageStream:
-  enabled: true
-  name: stream
-```
-
 #### Service-Monitor (works only on OpenShift)
 
-You can monitor metrics for a service by configuring monitoring stacks managed by the Cluster Observability Operator (COO)
+You can monitor metrics for a service by configuring monitoring stacks managed by the Cluster Observability Operator (COO) ([see also](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service#specifying-how-a-service-is-monitored-by-cluster-observability-operator_configuring_the_cluster_observability_operator_to_monitor_a_service)).
 
 ```yaml
     serviceMonitor:
       enabled: true
 ```
-
-[details](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/cluster_observability_operator/configuring-the-cluster-observability-operator-to-monitor-a-service#specifying-how-a-service-is-monitored-by-cluster-observability-operator_configuring_the_cluster_observability_operator_to_monitor_a_service)


### PR DESCRIPTION
**Description**

- moved global imagestream option to global configuration.
- inset links into sentence and renamed to "see also".

**Reference**

Issues #241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Moved Autorollout (OpenShift) guidance into the Gateway section with updated YAML examples and removed the duplicate Monitoring block.
  * Updated Service-Monitor documentation to include a link to the Cluster Observability Operator and improved formatting for clarity.

* **Chores**
  * Helm chart version bumped to 1.1.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->