### PR TITLE
Dave seperated deployment

### DIFF
--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.2.4
+version: 0.2.5
 maintainers:
   - name: klml
     email: klml@muenchen.de
@@ -25,15 +25,22 @@ dependencies:
     condition: externalCharts.keycloak.enabled
   - name: backend
     version: "*"
+    condition: externalCharts.backend.enabled
   - name: frontend
     version: "*"
+    condition: externalCharts.frontend.enabled
   - name: admin-portal
     version: "*"
+    condition: externalCharts.adminportal.enabled
   - name: selfservice-portal
     version: "*"
+    condition: externalCharts.selfserviceportal.enabled
   - name: eai
     version: "*"
+    condition: externalCharts.eai.enabled
   - name: document-storage
     version: "*"
+    condition: externalCharts.documentstorage.enabled
   - name: geodata-eai
     version: "*"
+    condition: externalCharts.geodataeai.enabled

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -67,7 +67,7 @@ backend:
       # DB
       # [By default such tables (and other objects) are automatically put into a schema named “public”. Every new database contains such a schema](https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PUBLIC).
       DB_SCHEMA: public
-      SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA: public
+      spring.jpa.properties.hibernate.default_schema: public
       SPRING_DATASOURCE_URL: jdbc:postgresql://dave-postgresql:5432/dave_db
       SPRING_DATASOURCE_USERNAME: dave
       SPRING_JPA_DATABASE: postgresql

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -28,6 +28,27 @@ externalCharts:
   keycloak:
     # enable/disable keycloak chart dependency
     enabled: true
+  backend:
+    # enable/disable backend chart dependency
+    enabled: true
+  frontend:
+    # enable/disable frontend chart dependency
+    enabled: true
+  adminportal:
+    # enable/disable adminportal chart dependency
+    enabled: true
+  selfserviceportal:
+    # enable/disable selfservice chart dependency
+    enabled: true
+  eai:
+    # enable/disable eai chart dependency
+    enabled: true
+  documentstorage:
+    # enable/disable documentstorage chart dependency
+    enabled: true
+  geodataeai:
+    # enable/disable geodataeai chart dependency
+    enabled: true
 
 # Dave Backend
 backend:


### PR DESCRIPTION
**Description**
Added option to disable every component of the deployment individually. For example, you can now specify that only the backend and frontend should be deployed without geodata-eai.

**Reference**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped chart version to 0.2.5.
  * Added conditional configuration flags for multiple dependencies, enabling selective deployment of backend, frontend, admin portal, self-service portal, EAI, document storage, and geodata EAI services.
  * Updated backend configuration for database schema settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->