### PR TITLE
conf(refarch-templates): decrease startup probe initial delay

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 1.1.10
+version: 1.1.11
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:
   - name: refarch-gateway
     condition: refarch-gateway.enabled
-    version: 1.7.1
+    version: 1.7.2
     repository: "@it-at-m"
 sources:
   - "https://github.com/it-at-m/helm-charts"

--- a/charts/refarch-templates/templates/deployment.yaml
+++ b/charts/refarch-templates/templates/deployment.yaml
@@ -67,7 +67,8 @@ spec:
             httpGet:
               path: /actuator/health
               port: http
-            initialDelaySeconds: 60
+            initialDelaySeconds: 10
+            failureThreshold: 9
             {{- end }}
           livenessProbe:
             {{- if $module.livenessProbe }}


### PR DESCRIPTION
**Description**

- refarch-templates: decrease startup probe initial delay to allow faster ready

**Reference**

- https://github.com/it-at-m/helm-charts/pull/245


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated chart version to 1.1.11
  * Updated refarch-gateway dependency to 1.7.2
  * Modified startup probe configuration with adjusted initial delay and added failure threshold

<!-- end of auto-generated comment: release notes by coderabbit.ai -->