### PR TITLE
Update kf-app-eai Chart for new CAP

### DIFF
--- a/charts/kf-app-eai/Chart.yaml
+++ b/charts/kf-app-eai/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kf-app-eai
 description: Enterprise application interface to allow Munich's kita-app access to kitafinder data.
 type: application
-version: 0.1.5
-appVersion: "1.0.2"
+version: 0.1.6
+appVersion: "1.0.6"
 maintainers:
   - name: maximilian-zollbrecht
     email: max.zollbrecht@gmail.com

--- a/charts/kf-app-eai/templates/ingress.yaml
+++ b/charts/kf-app-eai/templates/ingress.yaml
@@ -18,7 +18,7 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "kf-app-eai.labels" . | nindent 4 }}
-    type: web2tier
+    {{- include ".Values.ingress.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/kf-app-eai/templates/ingress.yaml
+++ b/charts/kf-app-eai/templates/ingress.yaml
@@ -18,6 +18,7 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "kf-app-eai.labels" . | nindent 4 }}
+    type: web2tier
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/kf-app-eai/templates/ingress.yaml
+++ b/charts/kf-app-eai/templates/ingress.yaml
@@ -18,7 +18,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "kf-app-eai.labels" . | nindent 4 }}
-    {{- include ".Values.ingress.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/kf-app-eai/values.yaml
+++ b/charts/kf-app-eai/values.yaml
@@ -46,6 +46,8 @@ service:
 ingress:
   enabled: false
   className: ""
+  labels:
+    type: web2tier
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
**Description**

Allows setting labels for the route for compatibility with new CAP cluster


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated application version from 1.0.2 to 1.0.6
  * Updated chart version from 0.1.5 to 0.1.6

* **Configuration Updates**
  * Enhanced ingress configuration to support additional labels
  * Added a "web2tier" label classification to ingress settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->