### PR TITLE
[dave] FV-34 Konfigurative Einbindung der Kartenlayer

### DIFF
--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -133,8 +133,17 @@ backend:
       DAVE_TENANT_MAP_CENTER_LAT: "48.89529"
       DAVE_TENANT_MAP_CENTER_LNG: "11.18026"
       DAVE_TENANT_MAP_CENTER_ZOOM: "12"
-      # Currently, only the maps of geoportal.muenchen.de are used, which cover the whole of Bavaria.
-      # FR for other maps https://github.com/it-at-m/dave/issues/4
+      # map base layers
+      DAVE_MAP_BASELAYERS_0_BASEURL: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+      DAVE_MAP_BASELAYERS_0_LAYERNAME: ""
+      DAVE_MAP_BASELAYERS_0_LAYERNAMETODISPLAY: "OpenStreetMap"
+      DAVE_MAP_BASELAYERS_0_ATTRIBUTION: "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>"
+      # map overlay layers
+      DAVE_MAP_OVERLAYLAYERS_0_BASEURL: ""
+      DAVE_MAP_OVERLAYLAYERS_0_LAYERNAME: ""
+      DAVE_MAP_OVERLAYLAYERS_0_LAYERNAMETODISPLAY: ""
+      DAVE_MAP_OVERLAYLAYERS_0_ATTRIBUTION: ""
+      
       # Dave Email Settings
       DAVE_EMAIL_URL_ADMINPORTAL: "http://localhost:8085"
       DAVE_EMAIL_URL_SELFSERVICEPORTAL: "http://localhost:8086"

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -134,15 +134,15 @@ backend:
       DAVE_TENANT_MAP_CENTER_LNG: "11.18026"
       DAVE_TENANT_MAP_CENTER_ZOOM: "12"
       # map base layers
-      DAVE_MAP_BASELAYERS_0_BASEURL: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
-      DAVE_MAP_BASELAYERS_0_LAYERNAME: ""
-      DAVE_MAP_BASELAYERS_0_LAYERNAMETODISPLAY: "OpenStreetMap"
-      DAVE_MAP_BASELAYERS_0_ATTRIBUTION: "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>"
+      DAVE_TENANT_MAP_BASELAYERS_0_BASEURL: "https://tile.openstreetmap.org/{z}/{x}/{y}.png"
+      DAVE_TENANT_MAP_BASELAYERS_0_LAYERNAME: ""
+      DAVE_TENANT_MAP_BASELAYERS_0_LAYERNAMETODISPLAY: "OpenStreetMap"
+      DAVE_TENANT_MAP_BASELAYERS_0_ATTRIBUTION: "&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a>"
       # map overlay layers
-      DAVE_MAP_OVERLAYLAYERS_0_BASEURL: ""
-      DAVE_MAP_OVERLAYLAYERS_0_LAYERNAME: ""
-      DAVE_MAP_OVERLAYLAYERS_0_LAYERNAMETODISPLAY: ""
-      DAVE_MAP_OVERLAYLAYERS_0_ATTRIBUTION: ""
+      DAVE_TENANT_MAP_OVERLAYLAYERS_0_BASEURL: ""
+      DAVE_TENANT_MAP_OVERLAYLAYERS_0_LAYERNAME: ""
+      DAVE_TENANT_MAP_OVERLAYLAYERS_0_LAYERNAMETODISPLAY: ""
+      DAVE_TENANT_MAP_OVERLAYLAYERS_0_ATTRIBUTION: ""
       
       # Dave Email Settings
       DAVE_EMAIL_URL_ADMINPORTAL: "http://localhost:8085"


### PR DESCRIPTION
**Description**

The map layers in DAVe can now be configured via application.yaml or helm chart values.yaml. This pull request adds a demo configuration to the values.yaml file.

**Reference**

Issues https://github.com/it-at-m/dave/issues/4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration options for tenant maps, including customizable base and overlay layers with OpenStreetMap tile URL templates, display names, and attribution settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/helm-charts/pull/259)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->