### PR TITLE
fix(refarch-templates): Fixed triggerAnnotation for deployments

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 2.0.2
+version: 2.0.3
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:

--- a/charts/refarch-templates/README.md
+++ b/charts/refarch-templates/README.md
@@ -5,10 +5,10 @@
 This chart bootstraps a sample RefArch deployment based on the architecture described in [RefArch documentation](https://refarch.oss.muenchen.de/overview.html) on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 It acts as an example and dependency to create Helm charts for deploying applications based on the RefArch and [its templates](https://refarch.oss.muenchen.de/templates/).
 It consists of the following components:
-- [refarch-backend](https://github.com/it-at-m/refarch-templates/tree/main/refarch-backend)
-- [refarch-eai](https://github.com/it-at-m/refarch-templates/tree/main/refarch-eai)
-- [refarch-frontend](https://github.com/it-at-m/refarch-templates/tree/main/refarch-frontend)
-- [refarch-webcomponent](https://github.com/it-at-m/refarch-templates/tree/main/refarch-webcomponent)
+- [backend](https://github.com/it-at-m/refarch-templates/tree/main/backend)
+- [eai](https://github.com/it-at-m/refarch-templates/tree/main/eai)
+- [frontend](https://github.com/it-at-m/refarch-templates/tree/main/frontend)
+- [webcomponent](https://github.com/it-at-m/refarch-templates/tree/main/webcomponent)
 
 > **Note:** This chart does not ship with an [API Gateway](https://refarch.oss.muenchen.de/gateway.html).
 If you need an API Gateway define it as an additional chart dependency. The respective chart can be found [here](https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-gateway)
@@ -150,7 +150,7 @@ Example:
     frontend:
       image:
         registry: ghcr.io
-        repository: it-at-m/refarch-templates/refarch-frontend
+        repository: it-at-m/refarch-templates/frontend
         pullPolicy: Always # Defaults to IfNotPresent
         tag: "latest"
 ```
@@ -347,7 +347,7 @@ The following configuration is picked up by default:
 ```
 
 > **Note:**: Those defaults are suitable for Spring-based applications, because applications like `refarch-backend` or `refarch-eai` expose those endpoints via Spring Actuator.
-Web components like `refarch-frontend` or `refarch-webcomponent` are compatible as well, as those mimic the actuator API
+Web deployments like `frontend` or `webcomponent` are compatible as well, as those mimic the actuator API
 
 #### Service-Monitor (works only on OpenShift)
 

--- a/charts/refarch-templates/ci/test-values.yaml
+++ b/charts/refarch-templates/ci/test-values.yaml
@@ -2,14 +2,14 @@ modules:
   frontend:
     image:
       registry: ghcr.io
-      repository: it-at-m/refarch-templates/refarch-frontend
+      repository: it-at-m/refarch-templates/frontend
       tag: "latest"
     service:
       http: true
   webcomponent:
     image:
       registry: ghcr.io
-      repository: it-at-m/refarch-templates/refarch-webcomponent
+      repository: it-at-m/refarch-templates/webcomponent
       tag: "latest"
     service:
       http: true
@@ -17,7 +17,7 @@ modules:
 #  - name: backend
 #    image:
 #      registry: ghcr.io
-#      repository: it-at-m/refarch-templates/refarch-backend
+#      repository: it-at-m/refarch-templates/backend
 #      tag: "latest"
 #    applicationYML:
 #      spring:
@@ -28,7 +28,7 @@ modules:
   eai:
     image:
       registry: ghcr.io
-      repository: it-at-m/refarch-templates/refarch-eai
+      repository: it-at-m/refarch-templates/eai
       tag: "latest"
     autoscaling:
       minReplicas: 2

--- a/charts/refarch-templates/ci/test-values.yaml
+++ b/charts/refarch-templates/ci/test-values.yaml
@@ -3,14 +3,14 @@ modules:
     image:
       registry: ghcr.io
       repository: it-at-m/refarch-templates/frontend
-      tag: "latest"
+      tag: "dev"
     service:
       http: true
   webcomponent:
     image:
       registry: ghcr.io
       repository: it-at-m/refarch-templates/webcomponent
-      tag: "latest"
+      tag: "dev"
     service:
       http: true
 # Commented out because backend currently cannot be tested publicly without DB connection
@@ -29,7 +29,7 @@ modules:
     image:
       registry: ghcr.io
       repository: it-at-m/refarch-templates/eai
-      tag: "latest"
+      tag: "dev"
     autoscaling:
       minReplicas: 2
       maxReplicas: 3

--- a/charts/refarch-templates/templates/deployment.yaml
+++ b/charts/refarch-templates/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ include "getFullname" $data }}
   {{- if $.Values.imageStream.enabled }}
   annotations:
-    {{- include "triggerAnnotation" (list .name $.Values.imageStream.name $.Release.Name ) | trim | nindent 4 }}
+    {{- include "triggerAnnotation" (list $moduleName $.Values.imageStream.name $.Release.Name ) | trim | nindent 4 }}
   {{- end }}
   labels:
     {{- include "getLabels" $data | trim | nindent 4 }}

--- a/charts/refarch-templates/values-example.yaml
+++ b/charts/refarch-templates/values-example.yaml
@@ -38,7 +38,7 @@ modules:
       # In Openshift you can use the ImageStreamTrigger. https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes
       # You can use direct the version number of an inmutable image. for example: 1.0.0
       registry: ghcr.io
-      repository: it-at-m/refarch-templates/refarch-frontend
+      repository: it-at-m/refarch-templates/frontend
       # pullPolicy: Always # Defaults to 'IfNotPresent', best choice for immutable images e.g. 1.0.0; 'Always' should be used for reference changing tags e.g. dev,test,latest and should be used in combination with `imageStream.enabled=true`
       tag: "1.0.0"
     env:
@@ -52,7 +52,7 @@ modules:
       # In Openshift you can use the ImageStreamTrigger. https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes
       # You can use direct the version number of an inmutable image. for example: 1.0.0
       registry: ghcr.io
-      repository: it-at-m/refarch-templates/refarch-webcomponent
+      repository: it-at-m/refarch-templates/webcomponent
       # pullPolicy: Always # Defaults to 'IfNotPresent', best choice for immutable images e.g. 1.0.0; 'Always' should be used for reference changing tags e.g. dev,test,latest and should be used in combination with `imageStream.enabled=true`
       tag: "1.0.0"
     env:
@@ -66,7 +66,7 @@ modules:
       # In Openshift you can use the ImageStreamTrigger. https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes
       # You can use direct the version number of an inmutable image. for example: 1.0.0
       registry: ghcr.io
-      repository: it-at-m/refarch-templates/refarch-backend
+      repository: it-at-m/refarch-templates/backend
       # pullPolicy: Always # Defaults to 'IfNotPresent', best choice for immutable images e.g. 1.0.0; 'Always' should be used for reference changing tags e.g. dev,test,latest and should be used in combination with `imageStream.enabled=true`
       tag: "1.0.0"
     envFrom:
@@ -104,7 +104,7 @@ modules:
       # In Openshift you can use the ImageStreamTrigger. https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/images/triggering-updates-on-imagestream-changes
       # You can use direct the version number of an inmutable image. for example: 1.0.0
       registry: ghcr.io
-      repository: it-at-m/refarch-templates/refarch-eai
+      repository: it-at-m/refarch-templates/eai
       # pullPolicy: Always # Defaults to 'IfNotPresent', best choice for immutable images e.g. 1.0.0; 'Always' should be used for reference changing tags e.g. dev,test,latest and should be used in combination with `imageStream.enabled=true`
       tag: "1.0.0"
     env:


### PR DESCRIPTION
**Description**

Changes

- Fixed wrong triggerAnnotation helper call that broke redeployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart version to 2.0.3.
  * Refined deployment image stream triggering configuration for better module reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->