### PR TITLE
changed naming of generated configmap

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 2.0.3
+version: 2.0.4
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:

--- a/charts/refarch-templates/templates/configmap.yaml
+++ b/charts/refarch-templates/templates/configmap.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "getFullname" $data }}
+  name: {{ $configmap.name }}
   labels:
     {{- include "getLabels" $data | trim  | nindent 4 }}
   annotations:


### PR DESCRIPTION
**Description**

Naming between configmap and secret was not consistent - this fixes this and leaves the naming strategy up to the developer

**Reference**

Issues #267 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ConfigMap naming implementation in Kubernetes deployment templates to reference configuration values directly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/helm-charts/pull/268)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->