### PR TITLE
chore(refarch-templates): bump refach-gateway to 1.8.0

### DIFF
--- a/charts/refarch-templates/Chart.yaml
+++ b/charts/refarch-templates/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: refarch-templates
 description: Helm Chart for deploying a it@M Reference Architecture application.
 type: application
-version: 2.0.4
+version: 2.1.0
 home: https://github.com/it-at-m/helm-charts/tree/main/charts/refarch-templates
 icon: https://raw.githubusercontent.com/it-at-m/helm-charts/main/images/logo.png
 dependencies:
   - name: refarch-gateway
     condition: refarch-gateway.enabled
-    version: 1.7.2
+    version: 1.8.0
     repository: "@it-at-m"
 sources:
   - "https://github.com/it-at-m/helm-charts"


### PR DESCRIPTION
**Description**

- chore(refarch-templates): bump refarch-gateway chart dependency to 1.8.0

**Reference**

- https://github.com/it-at-m/helm-charts/pull/261


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated chart package version to 2.1.0
  * Bumped refarch-gateway dependency to version 1.8.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/helm-charts/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->