### PR TITLE
chore: remove Chart.lock from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 ### Helm ###
 # Chart dependencies
 **/charts/*.tgz
-**/Chart.lock
 
 ## local values file
 values-local.yaml


### PR DESCRIPTION
**Description**

- chore: remove `Chart.lock` from `.gitignore` that it can be commited in the future

**Reference**

Introduced with https://github.com/it-at-m/helm-charts/pull/40/changes#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947
