### PR TITLE
fix(zammad-ldap-sync): remove unwanted sample defaults from values.yaml

### DIFF
--- a/charts/zammad-ldap-sync/Chart.yaml
+++ b/charts/zammad-ldap-sync/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: zammad-ldap-sync
-version: 0.6.3
+version: 0.6.4
 maintainers:
   - name: klml
     email: klml@muenchen.de

--- a/charts/zammad-ldap-sync/values.yaml
+++ b/charts/zammad-ldap-sync/values.yaml
@@ -28,16 +28,16 @@ ldapSync:
     sync:
     # If necessary, set different distinguished-names with their own ldap-search-bases.
       organizational-units:
-        identifier-1:
-          distinguished-names:
-#          - dn-identifier-1
-          user-search-base: user-dn-search-base-dent-1
-          ou-search-base: ou-dn-search-base-dent-1
-        identifier-2:
-          distinguished-names:
-#          - dn-identifier-2
-          user-search-base: user-dn-search-base-dent-2
-          ou-search-base: ou-dn-search-base-dent-2
+        # identifier-1:
+          # distinguished-names:
+            # - dn-identifier-1
+          # user-search-base: user-dn-search-base-dent-1
+          # ou-search-base: ou-dn-search-base-dent-1
+        # identifier-2:
+          # distinguished-names:
+            # - dn-identifier-2
+          # user-search-base: user-dn-search-base-dent-2
+          # ou-search-base: ou-dn-search-base-dent-2
       message:
         from: test@example.com
         to: test@example.com


### PR DESCRIPTION
**Description**

Having fixed sample values in the map caused them to be merged with actual configs in prod:

```
        actual-value:
          distinguished-names:
          - ou=blabla
          ou-search-base: blabla
          user-search-base: blabla
        identifier-1:
          distinguished-names: null
          ou-search-base: ou-dn-search-base-dent-1
          user-search-base: user-dn-search-base-dent-1
        identifier-2:
          distinguished-names: null
          ou-search-base: ou-dn-search-base-dent-2
          user-search-base: user-dn-search-base-dent-2
```

which in turn lead to errors when running the zammad-ldap-sync:

```
!!! No ldap nodes for all ouBases found. Please check the ouBase(s) (ldap distinguished name)
availability. Maybe part of a distinguished name was renamed in ldap :
!!! -
!!! -
```

**Reference**

https://git.muenchen.de/dbs-ops/infra/-/work_items/156 (internal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Commented out sample organizational-unit LDAP examples to avoid using placeholder per-identifier search settings while keeping the active LDAP sync structure intact.
  * Bumped the chart version to 0.6.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->