### PR TITLE
Fv 441 resourcen für portale im helm chart definieren

### DIFF
--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.2.8
+version: 0.2.9
 maintainers:
   - name: klml
     email: klml@muenchen.de

--- a/charts/dave/charts/admin-portal/Chart.yaml
+++ b/charts/dave/charts/admin-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admin-portal
 description: DAVe traffic counting plattform, admin-portal
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: "6.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/admin-portal/values.yaml
+++ b/charts/dave/charts/admin-portal/values.yaml
@@ -70,11 +70,6 @@ ingress:
   #      - chart-example.local
 
 resources:
-  # {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 250m
     memory: 1Gi

--- a/charts/dave/charts/admin-portal/values.yaml
+++ b/charts/dave/charts/admin-portal/values.yaml
@@ -70,17 +70,17 @@ ingress:
   #      - chart-example.local
 
 resources:
-  {}
+  # {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 250m
+    memory: 1Gi
+  requests:
+    cpu: 50m
+    memory: 1Gi
 
 autoscaling:
   enabled: false

--- a/charts/dave/charts/backend/Chart.yaml
+++ b/charts/dave/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: DAVe traffic counting plattform, backend
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: "6.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/backend/values.yaml
+++ b/charts/dave/charts/backend/values.yaml
@@ -70,11 +70,6 @@ ingress:
   #      - chart-example.local
 
 resources:
-  #{}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 1500m
     memory: 3512Mi

--- a/charts/dave/charts/document-storage/Chart.yaml
+++ b/charts/dave/charts/document-storage/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: document-storage
 description: DAVe traffic counting platform, document-storage
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: "6.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/document-storage/values.yaml
+++ b/charts/dave/charts/document-storage/values.yaml
@@ -66,11 +66,6 @@ ingress:
   #      - chart-example.local
 
 resources:
-  #{}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 500m
     memory: 512Mi

--- a/charts/dave/charts/eai/Chart.yaml
+++ b/charts/dave/charts/eai/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: eai
 description: DAVe traffic counting plattform, eai
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: "6.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/eai/values.yaml
+++ b/charts/dave/charts/eai/values.yaml
@@ -66,17 +66,12 @@ ingress:
   #      - chart-example.local
 
 resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 250m
+    memory: 500Mi
+  requests:
+    cpu: 50m
+    memory: 500Mi
 
 autoscaling:
   enabled: false

--- a/charts/dave/charts/frontend/Chart.yaml
+++ b/charts/dave/charts/frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: frontend
 description: DAVe traffic counting plattform, frontend
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: "6.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/frontend/values.yaml
+++ b/charts/dave/charts/frontend/values.yaml
@@ -70,11 +70,6 @@ ingress:
   #      - chart-example.local
 
 resources:
-  # {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 250m
     memory: 1Gi

--- a/charts/dave/charts/frontend/values.yaml
+++ b/charts/dave/charts/frontend/values.yaml
@@ -70,17 +70,18 @@ ingress:
   #      - chart-example.local
 
 resources:
-  {}
+  # {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 250m
+    memory: 1Gi
+  requests:
+    cpu: 50m
+    memory: 1Gi
+
 
 autoscaling:
   enabled: false

--- a/charts/dave/charts/geodata-eai/Chart.yaml
+++ b/charts/dave/charts/geodata-eai/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: geodata-eai
 description: DAVe traffic counting platform, geodata-eai
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: "6.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/geodata-eai/values.yaml
+++ b/charts/dave/charts/geodata-eai/values.yaml
@@ -66,11 +66,6 @@ ingress:
   #      - chart-example.local
 
 resources:
-  #{}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 500m
     memory: 512Mi

--- a/charts/dave/charts/selfservice-portal/Chart.yaml
+++ b/charts/dave/charts/selfservice-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: selfservice-portal
 description: DAVe traffic counting plattform, selfservice-portal
 type: application
-version: 0.2.8
+version: 0.2.9
 appVersion: "6.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/selfservice-portal/values.yaml
+++ b/charts/dave/charts/selfservice-portal/values.yaml
@@ -70,11 +70,6 @@ ingress:
   #      - chart-example.local
 
 resources:
-  # {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   limits:
     cpu: 250m
     memory: 1Gi

--- a/charts/dave/charts/selfservice-portal/values.yaml
+++ b/charts/dave/charts/selfservice-portal/values.yaml
@@ -70,17 +70,17 @@ ingress:
   #      - chart-example.local
 
 resources:
-  {}
+  # {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  limits:
+    cpu: 250m
+    memory: 1Gi
+  requests:
+    cpu: 50m
+    memory: 1Gi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
**Description**

CPU and RAM resources defined for portals.

**Reference**

Issues FV-441, #136 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped several Helm chart versions from `0.2.8` to `0.2.9` across the release.

* **New Features**
  * Added default CPU and memory resource settings for the admin portal, frontend, and self-service portal charts.
  * Default resources now include `requests` and `limits`, helping deployments start with clearer runtime capacity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->