### PR TITLE
FV-440 FOSS: K8s default im Helm-Chart verwenden

### DIFF
--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.2.12
+version: 0.2.13
 maintainers:
   - name: klml
     email: klml@muenchen.de

--- a/charts/dave/charts/admin-portal/Chart.yaml
+++ b/charts/dave/charts/admin-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admin-portal
 description: DAVe traffic counting plattform, admin-portal
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/admin-portal/values.yaml
+++ b/charts/dave/charts/admin-portal/values.yaml
@@ -32,13 +32,13 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+#  {}
+   capabilities:
+     drop:
+      - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/dave/charts/backend/Chart.yaml
+++ b/charts/dave/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: DAVe traffic counting plattform, backend
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/backend/values.yaml
+++ b/charts/dave/charts/backend/values.yaml
@@ -32,13 +32,13 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+#  {}
+   capabilities:
+     drop:
+      - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/dave/charts/document-storage/Chart.yaml
+++ b/charts/dave/charts/document-storage/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: document-storage
 description: DAVe traffic counting platform, document-storage
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/document-storage/values.yaml
+++ b/charts/dave/charts/document-storage/values.yaml
@@ -32,13 +32,13 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+#  {}
+   capabilities:
+     drop:
+       - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/dave/charts/eai/Chart.yaml
+++ b/charts/dave/charts/eai/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: eai
 description: DAVe traffic counting plattform, eai
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/eai/values.yaml
+++ b/charts/dave/charts/eai/values.yaml
@@ -32,13 +32,13 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+#  {}
+   capabilities:
+     drop:
+      - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/dave/charts/frontend/Chart.yaml
+++ b/charts/dave/charts/frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: frontend
 description: DAVe traffic counting plattform, frontend
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/frontend/values.yaml
+++ b/charts/dave/charts/frontend/values.yaml
@@ -32,13 +32,13 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+#  {}
+   capabilities:
+     drop:
+       - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/dave/charts/geodata-eai/Chart.yaml
+++ b/charts/dave/charts/geodata-eai/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: geodata-eai
 description: DAVe traffic counting platform, geodata-eai
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/geodata-eai/values.yaml
+++ b/charts/dave/charts/geodata-eai/values.yaml
@@ -32,13 +32,13 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+#  {}
+   capabilities:
+     drop:
+       - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/dave/charts/selfservice-portal/Chart.yaml
+++ b/charts/dave/charts/selfservice-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: selfservice-portal
 description: DAVe traffic counting plattform, selfservice-portal
 type: application
-version: 0.2.12
+version: 0.2.13
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/selfservice-portal/values.yaml
+++ b/charts/dave/charts/selfservice-portal/values.yaml
@@ -32,13 +32,13 @@ podSecurityContext:
   # fsGroup: 2000
 
 securityContext:
-  {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+#  {}
+   capabilities:
+     drop:
+       - ALL
+   readOnlyRootFilesystem: true
+   runAsNonRoot: true
+   runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/dave/values-openshift.yaml
+++ b/charts/dave/values-openshift.yaml
@@ -1,0 +1,32 @@
+# Additional values for dave for OpenShift environments.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Dave Backend
+backend:
+  securityContext: null
+
+# Dave Admin-Portal
+admin-portal:
+  securityContext: null
+
+# Dave Frontend
+frontend:
+  securityContext: null
+
+# Dave Selfservice-Portal
+selfservice-portal:
+  securityContext: null
+
+# Dave EAI
+eai:
+  securityContext: null
+
+# Dave Document-Storage
+document-storage:
+  securityContext: null
+
+# Dave Geodata-EAI
+geodata-eai:
+  securityContext: null
+


### PR DESCRIPTION
**Description**

securityContext filled

**Reference**

Issues #137 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Hardened container defaults across application components by dropping Linux capabilities, requiring non-root execution, using a fixed user, and enabling read-only root filesystems.
  - Added OpenShift-specific deployment values with component-level security overrides.

- **Chores**
  - Updated Helm chart versions from 0.2.12 to 0.2.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->