### PR TITLE
Fv 514 bitnami chart dependencies keycloak fehlt

### DIFF
--- a/charts/dave/Chart.yaml
+++ b/charts/dave/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dave
 description: DAVe traffic counting plattform
 type: application
-version: 0.2.13
+version: 0.2.14
 maintainers:
   - name: klml
     email: klml@muenchen.de
@@ -19,10 +19,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     version: 18.2.0
     condition: externalCharts.postgresql.enabled
-  - name: keycloak
-    repository: https://charts.bitnami.com/bitnami
-    version: 25.2.0
-    condition: externalCharts.keycloak.enabled
   - name: backend
     version: "*"
     condition: externalCharts.backend.enabled

--- a/charts/dave/charts/admin-portal/Chart.yaml
+++ b/charts/dave/charts/admin-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: admin-portal
 description: DAVe traffic counting plattform, admin-portal
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/backend/Chart.yaml
+++ b/charts/dave/charts/backend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: backend
 description: DAVe traffic counting plattform, backend
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/document-storage/Chart.yaml
+++ b/charts/dave/charts/document-storage/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: document-storage
 description: DAVe traffic counting platform, document-storage
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/document-storage/values.yaml
+++ b/charts/dave/charts/document-storage/values.yaml
@@ -70,7 +70,7 @@ resources:
     cpu: 500m
     memory: 512Mi
   requests:
-    cpu: 500m
+    cpu: 100m
     memory: 256Mi
 
 autoscaling:

--- a/charts/dave/charts/eai/Chart.yaml
+++ b/charts/dave/charts/eai/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: eai
 description: DAVe traffic counting plattform, eai
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/frontend/Chart.yaml
+++ b/charts/dave/charts/frontend/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: frontend
 description: DAVe traffic counting plattform, frontend
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/geodata-eai/Chart.yaml
+++ b/charts/dave/charts/geodata-eai/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: geodata-eai
 description: DAVe traffic counting platform, geodata-eai
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/charts/geodata-eai/values.yaml
+++ b/charts/dave/charts/geodata-eai/values.yaml
@@ -70,7 +70,7 @@ resources:
     cpu: 500m
     memory: 512Mi
   requests:
-    cpu: 500m
+    cpu: 100m
     memory: 256Mi
 
 autoscaling:

--- a/charts/dave/charts/selfservice-portal/Chart.yaml
+++ b/charts/dave/charts/selfservice-portal/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: selfservice-portal
 description: DAVe traffic counting plattform, selfservice-portal
 type: application
-version: 0.2.13
+version: 0.2.14
 appVersion: "10.0.0"
 maintainers:
   - name: klml

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -18,7 +18,7 @@ backend:
         --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
         --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
-      KEYCLOAK_AUTH-SERVER-URL: http://dave-keycloak
+      KEYCLOAK_AUTH_SERVER_URL: http://dave-keycloak
     # Dave Email Settings
     email:
       DAVE_EMAIL_RECEIVER_HOSTNAME: imap.example.com
@@ -49,8 +49,7 @@ admin-portal:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_URI: http://dave-keycloak/
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -96,8 +95,7 @@ frontend:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_URI: http://dave-keycloak/
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -127,8 +125,7 @@ selfservice-portal:
       java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens
       java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
       --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
-    SPRING_CLOUD_GATEWAY_ROUTES_0_URI: http://dave-keycloak/
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER-URI: http://dave-keycloak/realms/${spring.realm}
+    SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_URI: http://dave-keycloak/
   # Volume for CA-Certfificates
   # extraVolumeMounts:
   #   - name: cacerts
@@ -153,15 +150,9 @@ document-storage:
   # Environment variables
   extraEnvVars:
     JAVA_OPTIONS: -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit -Xmx512m
-    KEYCLOAK_AUTH-SERVER-URL: http://dave-keycloak
+    SPRING_PROFILES_ACTIVE: dev,no-security
+    KEYCLOAK_AUTH_SERVER_URL: http://dave-keycloak
     REFARCH_S3_URL: s3.example.com
     REFARCH_S3_BUCKETNAME: DAVE-BUCKET
     REFARCH_S3_ACCESSKEY: EXAMPLE
     REFARCH_S3_SECRETKEY: dummysecret
-
-keycloak:
-  fullnameOverride: "dave-keycloak"
-  keycloakConfigCli:
-    annotations:
-      # to trigger immediate execution of keycloak-config-ci
-      helm.sh/hook: null

--- a/charts/dave/ci/test-values.yaml
+++ b/charts/dave/ci/test-values.yaml
@@ -18,7 +18,6 @@ backend:
         --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED
         --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED
         --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED"
-      KEYCLOAK_AUTH_SERVER_URL: http://dave-keycloak
     # Dave Email Settings
     email:
       DAVE_EMAIL_RECEIVER_HOSTNAME: imap.example.com
@@ -151,7 +150,6 @@ document-storage:
   extraEnvVars:
     JAVA_OPTIONS: -Djavax.net.ssl.trustStore=/mnt/cacerts -Djavax.net.ssl.trustStorePassword=changeit -Xmx512m
     SPRING_PROFILES_ACTIVE: dev,no-security
-    KEYCLOAK_AUTH_SERVER_URL: http://dave-keycloak
     REFARCH_S3_URL: s3.example.com
     REFARCH_S3_BUCKETNAME: DAVE-BUCKET
     REFARCH_S3_ACCESSKEY: EXAMPLE

--- a/charts/dave/values.yaml
+++ b/charts/dave/values.yaml
@@ -25,9 +25,6 @@ externalCharts:
   postgresql:
     # enable/disable postgresql chart dependency
     enabled: true
-  keycloak:
-    # enable/disable keycloak chart dependency
-    enabled: true
   backend:
     # enable/disable backend chart dependency
     enabled: true
@@ -86,7 +83,7 @@ backend:
       HAZELCAST_OPENSHIFTSERVICENAME: dave-backend-service
       HAZELCAST_OPENSHIFTNAMESPACE: dave-ng-demo
       SERVER_PORT: "8080"
-      SPRING_PROFILES_ACTIVE: dev
+      SPRING_PROFILES_ACTIVE: dev,no-security
       # fixes missing fonts bug
       ORG_APACHE_POI_SS_IGNOREMISSINGFONTSYSTEM: "true"
       # Elasticsearch
@@ -169,6 +166,7 @@ backend:
   extraEnvVarsSources: []
   extraVolumeMounts: []
   extraVolumes: []
+
 # Dave Admin-Portal
 admin-portal:
   replicaCount: 1
@@ -182,7 +180,7 @@ admin-portal:
     HAZELCAST_OPENSHIFT_SERVICE_NAME: dave-adminportal-apigateway-service
 
     SERVER_PORT: "8080"
-    SPRING_PROFILES_ACTIVE: dev
+    SPRING_PROFILES_ACTIVE: dev,no-security
     SPRING_CLOUD_GATEWAY_ACTUATOR_VERBOSE_ENABLED: "false"
     SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_ID: sso
     SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_URI: <SSO URI>
@@ -218,7 +216,7 @@ eai:
     BACKEND_URI: dave-backend-service:8080
     MANAGEMENT_SERVER_PORT: "8079"
     SERVER_PORT: "8080"
-    SPRING_PROFILES_ACTIVE: dev
+    SPRING_PROFILES_ACTIVE: dev,no-security
 
   extraVolumeMounts: []
   extraVolumes: []
@@ -236,7 +234,7 @@ frontend:
     HAZELCAST_OPENSHIFT_SERVICE_NAME: dave-frontend-apigateway-service
 
     SERVER_PORT: "8080"
-    SPRING_PROFILES_ACTIVE: dev
+    SPRING_PROFILES_ACTIVE: dev,no-security
     SPRING_CLOUD_GATEWAY_ACTUATOR_VERBOSE_ENABLED: "false"
     SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_ID: sso
     SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_URI: <SSO URI>
@@ -280,7 +278,7 @@ selfservice-portal:
     HAZELCAST_OPENSHIFT_SERVICE_NAME: dave-selfserviceportal-apigateway-service
 
     SERVER_PORT: "8080"
-    SPRING_PROFILES_ACTIVE: dev
+    SPRING_PROFILES_ACTIVE: dev,no-security
     SPRING_CLOUD_GATEWAY_ACTUATOR_VERBOSE_ENABLED: "false"
     SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_ID: sso
     SPRING_CLOUD_GATEWAY_SERVER_WEBFLUX_ROUTES_0_URI: <SSO URI>
@@ -318,18 +316,9 @@ document-storage:
     GC_MAX_METASPACE_SIZE: "256"
     MANAGEMENT_SERVER_PORT: "8079"
     SERVER_PORT: "8080"
-    SPRING_PROFILES_ACTIVE: dev
+    SPRING_PROFILES_ACTIVE: dev,no-security
     # Security
-    REALM: Dave
     SPRING_SECURITY_LOGGING_REQUESTS: all
-    SPRING_SECURITY_OAUTH2_RESOURCE_USER-INFO-URI: ${keycloak.auth-server-url}/realms/${realm}/protocol/openid-connect/userinfo
-    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER-URI: ${keycloak.auth-server-url}/realms/${realm}
-    SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK-SET-URI: ${keycloak.auth-server-url}/realms/${realm}/protocol/openid-connect/certs
-    SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_TOKEN_URI: ${keycloak.auth-server-url}/realms/${realm}/protocol/openid-connect/token
-    SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT-ID: dave
-    SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT-SECRET: <CLIENT-SECRET>
-    SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_AUTHORIZATION-GRANT-TYPE: client_credentials
-    SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT-AUTHENTICATION-METHOD: client_secret_post
     # S3
     REFARCH_S3_URL: <S3-URL>
     REFARCH_S3_BUCKETNAME: <BUCKET-NAME>
@@ -350,16 +339,9 @@ geodata-eai:
       GC_MAX_METASPACE_SIZE: "256"
       MANAGEMENT_SERVER_PORT: "8079"
       SERVER_PORT: "8080"
-      SPRING_PROFILES_ACTIVE: dev
+      SPRING_PROFILES_ACTIVE: dev,no-security
       # Security
       SPRING_SECURITY_LOGGING_REQUESTS: all
-      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI: <URL-TO-ISSUER-URI>
-      SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWKSETURI: <URL-TO-JWK-SET-URI>
-      SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_SSO-MOBIDAM-MESSWERTE_TOKENURI: <URL-TO-MOBIDAM-TOKEN-URI>
-      SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_SSO-MOBIDAM-MESSWERTE_CLIENTID: <CLIENT-ID>
-      SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_SSO-MOBIDAM-MESSWERTE_CLIENTSECRET: <CLIENT-SECRET>
-      SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_SSO-MOBIDAM-MESSWERTE_AUTHORIZATIONGRANTTYPE: client_credentials
-      SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_SSO-MOBIDAM-MESSWERTE_CLIENTAUTHENTICATIONMETHOD: client_secret_post
       SPRING_CODEC_MAXINMEMORYSIZE: "52428800"
       # API for data extraction
       MOBIDAM_MESSWERTE_EAI_URL: <URL-TO-EAI-FOR-MESSWERTE-EXTRACTION>
@@ -424,43 +406,3 @@ postgresql:
       enabled: false
     podSecurityContext:
       enabled: false
-
-# Keycloak
-# https://github.com/bitnami/charts/tree/bitnami/keycloak
-keycloak:
-  postgresql:
-    nameOverride: keycloak-postgresql
-    # Workaround: switch to bitnami legacy image repository (https://github.com/bitnami/containers/issues/83267)
-    image:
-      repository: bitnamilegacy/postgresql
-image:
-  repository: bitnamilegacy/keycloak
-  global:
-    security:
-      allowInsecureImages: true
-
-  keycloakConfigCli:
-    enabled: true
-    initContainers: |
-      - name: fetch-config
-        image: {{ include "common.images.image" (dict "imageRoot" (dict "repository" "bitnami/os-shell" "tag" "latest") "global" .Values.global) }}
-        command:
-          - /bin/sh
-          - -c
-          - |
-            curl -L https://github.com/it-at-m/dave-backend/raw/refs/heads/sprint/sso-config/sso-client.json |
-              jq '{"clients": [.], "enabled": true, "realm": "Dave", "displayName": "DAVe"}' > /config/sso.json
-        volumeMounts:
-          - name: config-volume
-            mountPath: /config
-        securityContext: {{- include "common.compatibility.renderSecurityContext" (dict "secContext" .Values.keycloakConfigCli.containerSecurityContext "context" $) | nindent 4 }}
-    extraVolumes:
-      - name: config-volume
-        emptyDir:
-          sizeLimit: 10Mi
-    extraVolumeMounts:
-      - name: config-volume
-        mountPath: /config
-    extraEnvVars:
-      - name: IMPORT_FILES_LOCATIONS
-        value: /config/*


### PR DESCRIPTION
**Description**

Keycloak configuration removed

**Reference**

Issues FV-521, #185 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added development-mode configuration without security enforcement.
  * Updated service routing and authentication settings for more consistent deployments.

* **Bug Fixes**
  * Corrected authentication server configuration.
  * Reduced default CPU requests for document storage and geodata services.

* **Chores**
  * Released Helm charts as version 0.2.14.
  * Removed the bundled Keycloak chart and related configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->